### PR TITLE
Fixed re-shelving_library_books

### DIFF
--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -138,7 +138,7 @@ PLACE_ONTOP_SURFACE_OBJECT_TYPES = {
     'paper_towel', 'dishtowel', 'dial', 'folding_chair', 'deck', 'chair',
     'hamper', 'bed', 'plate', 'work_surface', 'board', 'pallet',
     'console_table', 'pool_table', 'electric_refrigerator', 'stand',
-    'room_floor'
+    'room_floor', 'notebook', 'hardback'
 }
 PLACE_INTO_SURFACE_OBJECT_TYPES = {
     'shelf', 'sack', 'basket', 'dredging_bucket', 'cabinet', 'crock', 'bucket',

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -381,11 +381,14 @@ def get_delta_low_level_hand_action(
 
 
 def check_nav_end_pose(
-        env: "BehaviorEnv", obj: Union["URDFObject", "RoomFloor"],
-        pos_offset: Array, ignore_blocked: bool = False) -> Optional[Tuple[List[int], List[int]]]:
+        env: "BehaviorEnv",
+        obj: Union["URDFObject", "RoomFloor"],
+        pos_offset: Array,
+        ignore_blocked: bool = False) -> Optional[Tuple[List[int], List[int]]]:
     """Check that the robot can reach pos_offset from the obj without (1) being
     in collision with anything, or (2) being blocked from obj by some other
-    solid object.
+    solid object. If ignore_blocked is True than we only check if (1) and do
+    not care if (2) the object is blocked.
 
     If this is true, return the ((x,y,z),(roll, pitch, yaw)), else
     return None
@@ -410,7 +413,8 @@ def check_nav_end_pose(
         env.robots[0].parts["body"].get_body_id(),
         obj.get_body_id(),
     ))
-    if not detect_robot_collision(env.robots[0]) and (not blocked or ignore_blocked):
+    if not detect_robot_collision(env.robots[0]) and (not blocked
+                                                      or ignore_blocked):
         valid_position = (pos, orn)
 
     p.restoreState(state)

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -382,7 +382,7 @@ def get_delta_low_level_hand_action(
 
 def check_nav_end_pose(
         env: "BehaviorEnv", obj: Union["URDFObject", "RoomFloor"],
-        pos_offset: Array) -> Optional[Tuple[List[int], List[int]]]:
+        pos_offset: Array, ignore_blocked: bool = False) -> Optional[Tuple[List[int], List[int]]]:
     """Check that the robot can reach pos_offset from the obj without (1) being
     in collision with anything, or (2) being blocked from obj by some other
     solid object.
@@ -410,7 +410,7 @@ def check_nav_end_pose(
         env.robots[0].parts["body"].get_body_id(),
         obj.get_body_id(),
     ))
-    if not detect_robot_collision(env.robots[0]) and not blocked:
+    if not detect_robot_collision(env.robots[0]) and (not blocked or ignore_blocked):
         valid_position = (pos, orn)
 
     p.restoreState(state)

--- a/predicators/behavior_utils/motion_planner_fns.py
+++ b/predicators/behavior_utils/motion_planner_fns.py
@@ -113,14 +113,13 @@ def make_navigation_plan(
         env.robots[0].parts["body"].get_body_id(),
         obj.get_body_id(),
     ))
-    if not detect_robot_collision(env.robots[0]) and not blocked:
+    if blocked:
+        logging.warning("WARNING: Position commanded is blocked!")
+    if not detect_robot_collision(env.robots[0]):
         valid_position = (pos, orn)
 
     if valid_position is None:
-        if blocked:
-            logging.warning("WARNING: Position commanded is blocked!")
-        else:
-            logging.warning("WARNING: Position commanded is in collision!")
+        logging.warning("WARNING: Position commanded is in collision!")
         p.restoreState(state)
         p.removeState(state)
         logging.warning(f"PRIMITIVE: navigate to {obj.name} with params "

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -311,7 +311,8 @@ class BehaviorEnv(BaseEnv):
             # on a particular state, and calling them after loading checkpoint
             # on that particular state. Doing this resolves that discrepancy.
             load_checkpoint_state(self.current_ig_state_to_state(), self)
-            # We let objects fall into place.
+            # Initial state objects might not have settled yet, so we step the
+            # simulator a few times to let the objects settle.
             for _ in range(15):
                 self.igibson_behavior_env.step(
                     np.zeros(self.igibson_behavior_env.action_space.shape))

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -289,6 +289,11 @@ class BehaviorEnv(BaseEnv):
                             while self.task_instance_id in broken_instances[
                                     'train']:
                                 self.task_instance_id = rng.integers(0, 10)
+                ##############
+                # Sets Env to specific task instance.
+                self.task_instance_id = 11
+                curr_env_seed = 3144494814
+                #############
                 if len(CFG.behavior_task_list) != 1:
                     self.set_config_by_task_num(self.task_num)
                 self.set_igibson_behavior_env(

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -289,11 +289,6 @@ class BehaviorEnv(BaseEnv):
                             while self.task_instance_id in broken_instances[
                                     'train']:
                                 self.task_instance_id = rng.integers(0, 10)
-                ##############
-                # Sets Env to specific task instance.
-                self.task_instance_id = 11
-                curr_env_seed = 3144494814
-                #############
                 if len(CFG.behavior_task_list) != 1:
                     self.set_config_by_task_num(self.task_num)
                 self.set_igibson_behavior_env(
@@ -316,6 +311,10 @@ class BehaviorEnv(BaseEnv):
             # on a particular state, and calling them after loading checkpoint
             # on that particular state. Doing this resolves that discrepancy.
             load_checkpoint_state(self.current_ig_state_to_state(), self)
+            # We let objects fall into place.
+            for _ in range(15):
+                self.igibson_behavior_env.step(
+                    np.zeros(self.igibson_behavior_env.action_space.shape))
             init_state = self.current_ig_state_to_state()
             goal = self._get_task_goal()
             task = Task(init_state, goal)

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -1,6 +1,5 @@
 """Definitions of ground truth NSRTs for all environments."""
 
-from faulthandler import disable
 import itertools
 import logging
 from typing import List, Sequence, Set, Union, cast
@@ -2846,7 +2845,10 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
             y = distance * np.sin(yaw)
             sampler_output = np.array([x, y])
             if obj_to_sample_near.category == "shelf":
-                if check_nav_end_pose(env.igibson_behavior_env, obj_to_sample_near, sampler_output, ignore_blocked=True):
+                if check_nav_end_pose(env.igibson_behavior_env,
+                                      obj_to_sample_near,
+                                      sampler_output,
+                                      ignore_blocked=True):
                     return sampler_output
             # NOTE: In many situations, it is impossible to find a good sample
             # no matter how many times we try. Thus, we break this loop after

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -1,5 +1,6 @@
 """Definitions of ground truth NSRTs for all environments."""
 
+from faulthandler import disable
 import itertools
 import logging
 from typing import List, Sequence, Set, Union, cast
@@ -2844,6 +2845,9 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
             x = distance * np.cos(yaw)
             y = distance * np.sin(yaw)
             sampler_output = np.array([x, y])
+            if obj_to_sample_near.category == "shelf":
+                if check_nav_end_pose(env.igibson_behavior_env, obj_to_sample_near, sampler_output, ignore_blocked=True):
+                    return sampler_output
             # NOTE: In many situations, it is impossible to find a good sample
             # no matter how many times we try. Thus, we break this loop after
             # a certain number of tries so the planner will backtrack.

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -281,6 +281,11 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
                     CFG.horizon)
                 outfile = f"{save_prefix}__task{test_task_idx+1}_failure.mp4"
                 utils.save_video(outfile, video)
+            # print("Failed")
+            # print("Task Num:", env.task_num)
+            # print("Task Instance ID:", env.task_instance_id)
+            # print("Task iGibson Seed:", env.task_num_task_instance_id_to_igibson_seed[(env.task_num, env.task_instance_id)])
+            # import ipdb; ipdb.set_trace()
             continue
         solve_time = time.perf_counter() - solve_start
         metrics[f"PER_TASK_task{test_task_idx}_solve_time"] = solve_time

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -281,11 +281,6 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
                     CFG.horizon)
                 outfile = f"{save_prefix}__task{test_task_idx+1}_failure.mp4"
                 utils.save_video(outfile, video)
-            # print("Failed")
-            # print("Task Num:", env.task_num)
-            # print("Task Instance ID:", env.task_instance_id)
-            # print("Task iGibson Seed:", env.task_num_task_instance_id_to_igibson_seed[(env.task_num, env.task_instance_id)])
-            # import ipdb; ipdb.set_trace()
             continue
         solve_time = time.perf_counter() - solve_start
         metrics[f"PER_TASK_task{test_task_idx}_solve_time"] = solve_time


### PR DESCRIPTION
This PR fixes re-shelving_library_books by not checking if objects are blocking view when sampling positions to shelfs and adding notebooks and hardbacks to the list of object types you can pick from.