### PR TITLE
Fixed order invariance test

### DIFF
--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -603,7 +603,7 @@ def test_backchaining_strips_learner_order_dependence():
         # Rename the output NSRT operators to standardize naming
         # and make comparison easier.
         op = nsrt.op.copy_with(name=nsrt.option.name + "0")
-        assert op in set([pnad.op for pnad in reverse_order_pnads])
+        assert op in set(pnad.op for pnad in reverse_order_pnads)
 
 
 def test_spawn_new_pnad():

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -597,6 +597,13 @@ def test_backchaining_strips_learner_order_dependence():
     # with our _MockBackchainingSTRIPSLearner that does not have these
     # additions.
     assert len(natural_order_nsrts) == len(reverse_order_nsrts)
+    # Lastly, check whether the natural order nsrts we generate are the
+    # same as the (correct) reverse_order_pnads.
+    for nsrt in natural_order_nsrts:
+        # Rename the output NSRT operators to standardize naming
+        # and make comparison easier.
+        op = nsrt.op.copy_with(name=nsrt.option.name + "0")
+        assert op in set([pnad.op for pnad in reverse_order_pnads])
 
 
 def test_spawn_new_pnad():


### PR DESCRIPTION
This PR fixes the order invariance test by making sure the NSRTs generated are the same as the correct ones.