### PR TITLE
implements PR to only create training data

### DIFF
--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -75,9 +75,8 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task],
                         "ERROR!: Collected only" +
                         f"{len(trajectories)} trajectories, but needed" +
                         f"{CFG.num_train_tasks}.")
-                raise AssertionError(
-                    "SUCCESS!: Created training dataset" +
-                    f"with {len(trajectories)} trajectories.")
+                raise AssertionError("SUCCESS!: Created training dataset" +
+                                     f"with {len(trajectories)} trajectories.")
 
     # NOTE: This is necessary because we replace BEHAVIOR
     # options with dummy options in order to pickle them, so

--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -66,6 +66,19 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task],
                     env.task_num_task_instance_id_to_igibson_seed
             with open(dataset_fname.replace(".data", ".info"), "wb") as f:
                 pkl.dump(info, f)
+            # If we're only interested in creating a training dataset, then
+            # terminate the program here and return how many demos were
+            # collected.
+            if CFG.create_training_dataset:
+                if CFG.num_train_tasks != len(trajectories):
+                    raise AssertionError(
+                        "ERROR!: Collected only" +
+                        f"{len(trajectories)} trajectories, but needed" +
+                        f"{CFG.num_train_tasks}.")
+                else:
+                    raise AssertionError(
+                        "SUCCESS!: Created training dataset" +
+                        f"with {len(trajectories)} trajectories.")
 
     # NOTE: This is necessary because we replace BEHAVIOR
     # options with dummy options in order to pickle them, so

--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -75,10 +75,9 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task],
                         "ERROR!: Collected only" +
                         f"{len(trajectories)} trajectories, but needed" +
                         f"{CFG.num_train_tasks}.")
-                else:
-                    raise AssertionError(
-                        "SUCCESS!: Created training dataset" +
-                        f"with {len(trajectories)} trajectories.")
+                raise AssertionError(
+                    "SUCCESS!: Created training dataset" +
+                    f"with {len(trajectories)} trajectories.")
 
     # NOTE: This is necessary because we replace BEHAVIOR
     # options with dummy options in order to pickle them, so

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -123,6 +123,7 @@ class GlobalSettings:
     behavior_randomize_init_state = True
     behavior_option_model_eval = False
     behavior_option_model_rrt = False
+    create_training_dataset = False
 
     # general pybullet parameters
     pybullet_draw_debug = False  # useful for annotating in the GUI


### PR DESCRIPTION
Example command:
```
python predicators/main.py --env behavior --approach nsrt_learning --strips_learner pnad_search --num_train_tasks 1 --num_test_tasks 1 --offline_data_planning_timeout 500.0 --timeout 500.0 --plan_only_eval True --sesame_task_planner fdopt --behavior_scene_name Ihlen_1_int --behavior_task_list [throwing_away_leftovers] --behavior_option_model_eval True --seed 456 --behavior_mode simple --create_training_dataset True
```