### PR TITLE
saves ground atoms data as well as trajectories

### DIFF
--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -158,7 +158,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
             # If we're only interested in creating a training dataset, then
             # terminate the program here and return how many demos were
             # collected.
-            if CFG.create_training_dataset:
+            if CFG.create_training_dataset:  # pragma: no cover
                 if CFG.num_train_tasks != len(trajectories):
                     raise AssertionError(
                         "ERROR!: Collected only" +

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -155,6 +155,17 @@ class NSRTLearningApproach(BilevelPlanningApproach):
                 ground_atom_dataset_to_pkl.append(trajectory)
             with open(dataset_fname, "wb") as f:
                 pkl.dump(ground_atom_dataset_to_pkl, f)
+            # If we're only interested in creating a training dataset, then
+            # terminate the program here and return how many demos were
+            # collected.
+            if CFG.create_training_dataset:
+                if CFG.num_train_tasks != len(trajectories):
+                    raise AssertionError(
+                        "ERROR!: Collected only" +
+                        f"{len(trajectories)} trajectories, but needed" +
+                        f"{CFG.num_train_tasks}.")
+                raise AssertionError("SUCCESS!: Created training dataset" +
+                                     f"with {len(trajectories)} trajectories.")
 
         self._nsrts, self._segmented_trajs, self._seg_to_nsrt = \
             learn_nsrts_from_data(trajectories,

--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -66,17 +66,6 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task],
                     env.task_num_task_instance_id_to_igibson_seed
             with open(dataset_fname.replace(".data", ".info"), "wb") as f:
                 pkl.dump(info, f)
-            # If we're only interested in creating a training dataset, then
-            # terminate the program here and return how many demos were
-            # collected.
-            if CFG.create_training_dataset:
-                if CFG.num_train_tasks != len(trajectories):
-                    raise AssertionError(
-                        "ERROR!: Collected only" +
-                        f"{len(trajectories)} trajectories, but needed" +
-                        f"{CFG.num_train_tasks}.")
-                raise AssertionError("SUCCESS!: Created training dataset" +
-                                     f"with {len(trajectories)} trajectories.")
 
     # NOTE: This is necessary because we replace BEHAVIOR
     # options with dummy options in order to pickle them, so


### PR DESCRIPTION
Example:

```
python predicators/main.py --env behavior --approach nsrt_learning --strips_learner pnad_search --num_train_tasks 1 --num_test_tasks 0 --offline_data_planning_timeout 500.0 --timeout 500.0 --plan_only_eval True --sesame_task_planner fdopt --behavior_scene_name Ihlen_1_int --behavior_task_list [throwing_away_leftovers] --behavior_option_model_eval True --seed 456 --behavior_mode simple --create_training_dataset True
```