### PR TITLE
Enables command line option to bypass learned samplers

### DIFF
--- a/predicators/behavior_utils/option_model_fns.py
+++ b/predicators/behavior_utils/option_model_fns.py
@@ -6,9 +6,12 @@ from typing import Callable, Dict, List
 
 import numpy as np
 import pybullet as p
+from numpy.random import RandomState
 
 from predicators import utils
-from predicators.behavior_utils.behavior_utils import ALL_RELEVANT_OBJECT_TYPES
+from predicators.behavior_utils.behavior_utils import \
+    ALL_RELEVANT_OBJECT_TYPES, sample_navigation_params
+from predicators.settings import CFG
 from predicators.structs import Object, State, Type
 
 try:
@@ -26,6 +29,10 @@ try:
 except (ImportError, ModuleNotFoundError) as e:
     pass
 
+# Necessary to ensure different numbers sampled within the
+# NavigateToOptionModel.
+prng = RandomState(10000)
+
 
 def create_navigate_option_model(
         plan: List[List[float]], _original_orientation: List[List[float]],
@@ -37,10 +44,25 @@ def create_navigate_option_model(
 
     def navigateToOptionModel(_init_state: State, env: "BehaviorEnv") -> None:
         robot_z = env.robots[0].get_position()[2]
-        target_pos = np.array([plan[-1][0], plan[-1][1], robot_z])
         robot_orn = p.getEulerFromQuaternion(env.robots[0].get_orientation())
+        if not CFG.behavior_override_learned_samplers:
+            desired_xpos = plan[-1][0]
+            desired_ypos = plan[-1][1]
+            desired_zrot = plan[-1][2]
+        else:
+            rng = np.random.default_rng(prng.randint(10000))
+            sample_arr = sample_navigation_params(env, _obj_to_nav_to, rng)
+            obj_pos = _obj_to_nav_to.get_position()
+            desired_xpos = sample_arr[0] + obj_pos[0]
+            desired_ypos = sample_arr[1] + obj_pos[1]
+            desired_zrot = np.arctan2(sample_arr[1], sample_arr[0]) - np.pi
+            logging.info("PRIMITIVE: Overriding sampler and attempting to " +
+                         f"navigate to {_obj_to_nav_to.name} with "
+                         f"params {sample_arr}")
+
+        target_pos = np.array([desired_xpos, desired_ypos, robot_z])
         target_orn = p.getQuaternionFromEuler(
-            np.array([robot_orn[0], robot_orn[1], plan[-1][2]]))
+            np.array([robot_orn[0], robot_orn[1], desired_zrot]))
         env.robots[0].set_position_orientation(target_pos, target_orn)
         # this is running a zero action to step simulator so
         # the environment updates to the correct final position

--- a/predicators/behavior_utils/option_model_fns.py
+++ b/predicators/behavior_utils/option_model_fns.py
@@ -45,6 +45,10 @@ def create_navigate_option_model(
     def navigateToOptionModel(_init_state: State, env: "BehaviorEnv") -> None:
         robot_z = env.robots[0].get_position()[2]
         robot_orn = p.getEulerFromQuaternion(env.robots[0].get_orientation())
+        # If we're not overriding the learned samplers, then we will directly
+        # use the elements of `plan`, which in turn use the outputs of the
+        # learned samplers. Otherwise, we will ignore these and use our
+        # oracle sampler to give us values to use.
         if not CFG.behavior_override_learned_samplers:
             desired_xpos = plan[-1][0]
             desired_ypos = plan[-1][1]

--- a/predicators/behavior_utils/option_model_fns.py
+++ b/predicators/behavior_utils/option_model_fns.py
@@ -56,7 +56,8 @@ def create_navigate_option_model(
             desired_xpos = sample_arr[0] + obj_pos[0]
             desired_ypos = sample_arr[1] + obj_pos[1]
             desired_zrot = np.arctan2(sample_arr[1], sample_arr[0]) - np.pi
-            logging.info("PRIMITIVE: Overriding sampler and attempting to " +
+            logging.info(f"PRIMITIVE: Overriding sample ({plan[-1][0]}" +
+                         f", {plan[-1][1]}) and attempting to " +
                          f"navigate to {_obj_to_nav_to.name} with "
                          f"params {sample_arr}")
 

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -26,8 +26,6 @@ from predicators.structs import NSRT, Array, GroundAtom, LiftedAtom, Object, \
 from predicators.utils import null_sampler
 
 try:  # pragma: no cover
-    from igibson.envs.behavior_env import \
-        BehaviorEnv  # pylint: disable=unused-import
     from igibson.external.pybullet_tools.utils import get_aabb, get_aabb_extent
     from igibson.object_states.on_floor import \
         RoomFloor  # pylint: disable=unused-import

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -10,7 +10,7 @@ from numpy.random._generator import Generator
 from predicators.behavior_utils.behavior_utils import OPENABLE_OBJECT_TYPES, \
     PICK_PLACE_OBJECT_TYPES, PLACE_INTO_SURFACE_OBJECT_TYPES, \
     PLACE_ONTOP_SURFACE_OBJECT_TYPES, check_hand_end_pose, \
-    check_nav_end_pose, load_checkpoint_state
+    load_checkpoint_state, sample_navigation_params
 from predicators.envs import get_or_create_env
 from predicators.envs.behavior import BehaviorEnv
 from predicators.envs.doors import DoorsEnv
@@ -26,6 +26,8 @@ from predicators.structs import NSRT, Array, GroundAtom, LiftedAtom, Object, \
 from predicators.utils import null_sampler
 
 try:  # pragma: no cover
+    from igibson.envs.behavior_env import \
+        BehaviorEnv  # pylint: disable=unused-import
     from igibson.external.pybullet_tools.utils import get_aabb, get_aabb_extent
     from igibson.object_states.on_floor import \
         RoomFloor  # pylint: disable=unused-import
@@ -2883,8 +2885,6 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
         return np.array([0.0, 0.0, 0.0])
 
     # NavigateTo sampler definition.
-    MAX_NAVIGATION_SAMPLES = 50
-
     def navigate_to_param_sampler(state: State, goal: Set[GroundAtom],
                                   rng: Generator,
                                   objects: Sequence["URDFObject"]) -> Array:
@@ -2902,41 +2902,8 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
         # The navigation nsrts are designed such that the target
         # obj is always last in the params list.
         obj_to_sample_near = objects[-1]
-        closeness_limit = 2.00
-        nearness_limit = 0.15
-        distance = nearness_limit + (
-            (closeness_limit - nearness_limit) * rng.random())
-        yaw = rng.random() * (2 * np.pi) - np.pi
-        x = distance * np.cos(yaw)
-        y = distance * np.sin(yaw)
-        sampler_output = np.array([x, y])
-        # The below while loop avoids sampling values that would put the
-        # robot in collision with some object in the environment. It may
-        # not always succeed at this and will exit after a certain number
-        # of tries.
-        logging.info("Sampling params for navigation...")
-        num_samples_tried = 0
-        while (check_nav_end_pose(env.igibson_behavior_env, obj_to_sample_near,
-                                  sampler_output) is None):
-            distance = closeness_limit * rng.random()
-            yaw = rng.random() * (2 * np.pi) - np.pi
-            x = distance * np.cos(yaw)
-            y = distance * np.sin(yaw)
-            sampler_output = np.array([x, y])
-            if obj_to_sample_near.category == "shelf":
-                if check_nav_end_pose(env.igibson_behavior_env,
-                                      obj_to_sample_near,
-                                      sampler_output,
-                                      ignore_blocked=True):
-                    return sampler_output
-            # NOTE: In many situations, it is impossible to find a good sample
-            # no matter how many times we try. Thus, we break this loop after
-            # a certain number of tries so the planner will backtrack.
-            if num_samples_tried > MAX_NAVIGATION_SAMPLES:
-                break
-            num_samples_tried += 1
-
-        return sampler_output
+        return sample_navigation_params(env.igibson_behavior_env,
+                                        obj_to_sample_near, rng)
 
     # Grasp sampler definition.
     def grasp_obj_param_sampler(state: State, goal: Set[GroundAtom],

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -126,6 +126,7 @@ class GlobalSettings:
     behavior_randomize_init_state = True
     behavior_option_model_eval = False
     behavior_option_model_rrt = False
+    behavior_override_learned_samplers = False
     create_training_dataset = False
 
     # general pybullet parameters

--- a/scripts/lisdf_plan_to_reset.py
+++ b/scripts/lisdf_plan_to_reset.py
@@ -1,7 +1,8 @@
 """Create a command that resets the robot from its current state to the initial
 state of another LISDF plan.
 
-Prepend that "reset" command with the other LISDF plan to create a final plan.
+Prepend that "reset" command with the other LISDF plan to create a final
+plan.
 """
 import argparse
 from pathlib import Path


### PR DESCRIPTION
There are various issues with our current sampler-learning setup for BEHAVIOR envs. This appears to be particularly giving us a hard time for navigation (likely because of the variation between training and test object locations :crying_cat_face: ). This PR is a hack to move the navigation sampler into the navigation option and thus avoid this issue.

Note that I created a separate command line flag instead of using `sampler_learner == 'oracle'` because we want to do this overriding behavior specifically for BEHAVIOR environments, and because using the oracle sampler learner tries to associate oracle samplers with options, which we might not want (we might still want to learn samplers for other options for example!).