### PR TITLE
Load ground atoms for GNN shooting

### DIFF
--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -12,6 +12,7 @@ import torch.optim
 from gym.spaces import Box
 
 from predicators import utils
+from predicators.behavior_utils import behavior_utils
 from predicators.approaches import ApproachFailure, ApproachTimeout
 from predicators.approaches.gnn_approach import GNNApproach
 from predicators.nsrt_learning.segmentation import segment_trajectory
@@ -43,8 +44,8 @@ class GNNOptionPolicyApproach(GNNApproach):
         self, dataset: Dataset
     ) -> List[Tuple[State, Set[GroundAtom], Set[GroundAtom], _Option]]:
         data = []
-        ground_atom_dataset = utils.create_ground_atom_dataset(
-            dataset.trajectories, self._initial_predicates)
+        ground_atom_dataset = behavior_utils.load_or_make_new_ground_atom_dataset(
+            dataset.trajectories, self._initial_predicates, None)
         # In this approach, we never learned any NSRTs, so we just call
         # segment_trajectory() to segment the given dataset.
         segmented_trajs = [

--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -12,9 +12,9 @@ import torch.optim
 from gym.spaces import Box
 
 from predicators import utils
-from predicators.behavior_utils import behavior_utils
 from predicators.approaches import ApproachFailure, ApproachTimeout
 from predicators.approaches.gnn_approach import GNNApproach
+from predicators.behavior_utils import behavior_utils
 from predicators.nsrt_learning.segmentation import segment_trajectory
 from predicators.option_model import create_option_model
 from predicators.settings import CFG
@@ -44,7 +44,7 @@ class GNNOptionPolicyApproach(GNNApproach):
         self, dataset: Dataset
     ) -> List[Tuple[State, Set[GroundAtom], Set[GroundAtom], _Option]]:
         data = []
-        ground_atom_dataset = behavior_utils.load_or_make_new_ground_atom_dataset(
+        ground_atom_dataset = behavior_utils.get_ground_atoms_dataset(
             dataset.trajectories, self._initial_predicates, None)
         # In this approach, we never learned any NSRTs, so we just call
         # segment_trajectory() to segment the given dataset.

--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -14,7 +14,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.approaches import ApproachFailure, ApproachTimeout
 from predicators.approaches.gnn_approach import GNNApproach
-from predicators.behavior_utils import behavior_utils
+from predicators.nsrt_learning.nsrt_learning_main import \
+    get_ground_atoms_dataset
 from predicators.nsrt_learning.segmentation import segment_trajectory
 from predicators.option_model import create_option_model
 from predicators.settings import CFG
@@ -44,7 +45,7 @@ class GNNOptionPolicyApproach(GNNApproach):
         self, dataset: Dataset
     ) -> List[Tuple[State, Set[GroundAtom], Set[GroundAtom], _Option]]:
         data = []
-        ground_atom_dataset = behavior_utils.get_ground_atoms_dataset(
+        ground_atom_dataset = get_ground_atoms_dataset(
             dataset.trajectories, self._initial_predicates, None)
         # In this approach, we never learned any NSRTs, so we just call
         # segment_trajectory() to segment the given dataset.

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -68,104 +68,11 @@ class NSRTLearningApproach(BilevelPlanningApproach):
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
                      online_learning_cycle: Optional[int]) -> None:
-        dataset_fname, _ = utils.create_dataset_filename_str(
-            saving_ground_atoms=True,
-            online_learning_cycle=online_learning_cycle)
-        # If CFG.load_atoms is set, then try to create a GroundAtomTrajectory
-        # by loading sets of GroundAtoms directly from a saved file.
-        if CFG.load_atoms:
-            os.makedirs(CFG.data_dir, exist_ok=True)
-            # Check that the dataset file was previously saved.
-            if os.path.exists(dataset_fname):
-                # Load the ground atoms dataset.
-                with open(dataset_fname, "rb") as f:
-                    ground_atom_dataset_atoms = pkl.load(f)
-                assert len(trajectories) == len(ground_atom_dataset_atoms)
-                logging.info("\n\nLOADED GROUND ATOM DATASET")
-
-                if CFG.env == "behavior":  # pragma: no cover
-                    pred_name_to_pred = {
-                        pred.name: pred
-                        for pred in self._get_current_predicates()
-                    }
-                    new_ground_atom_dataset_atoms = []
-                    # Since we save ground atoms for behavior with dummy
-                    # classifiers, we need to restore the correct classifers.
-                    for ground_atom_seq in ground_atom_dataset_atoms:
-                        new_ground_atom_seq = []
-                        for ground_atom_set in ground_atom_seq:
-                            new_ground_atom_set = {
-                                GroundAtom(
-                                    pred_name_to_pred[atom.predicate.name],
-                                    atom.entities)
-                                for atom in ground_atom_set
-                            }
-                            new_ground_atom_seq.append(new_ground_atom_set)
-                        new_ground_atom_dataset_atoms.append(
-                            new_ground_atom_seq)
-
-                # The saved ground atom dataset consists only of sequences
-                # of sets of GroundAtoms, we need to recombine this with
-                # the LowLevelTrajectories to create a GroundAtomTrajectory.
-                ground_atom_dataset = []
-                for i, traj in enumerate(trajectories):
-                    if CFG.env == "behavior":
-                        ground_atom_seq = new_ground_atom_dataset_atoms[
-                            i]  # pragma: no cover
-                    else:
-                        ground_atom_seq = ground_atom_dataset_atoms[i]
-                    ground_atom_dataset.append(
-                        (traj, [set(atoms) for atoms in ground_atom_seq]))
-            else:
-                raise ValueError(f"Cannot load ground atoms: {dataset_fname}")
-        else:
-            # Apply predicates to data, producing a dataset of abstract states.
-            if CFG.env == "behavior":  # pragma: no cover
-                env = get_or_create_env("behavior")
-                assert isinstance(env, BehaviorEnv)
-                ground_atom_dataset = \
-                    behavior_utils.create_ground_atom_dataset_behavior(
-                        trajectories, self._get_current_predicates(), env)
-            else:
-                ground_atom_dataset = utils.create_ground_atom_dataset(
-                    trajectories, self._get_current_predicates())
-            # Save ground atoms dataset to file. Note that a
-            # GroundAtomTrajectory contains a normal LowLevelTrajectory and a
-            # list of sets of GroundAtoms, so we only save the list of
-            # GroundAtoms (the LowLevelTrajectories are saved separately).
-            ground_atom_dataset_to_pkl = []
-            for gt_traj in ground_atom_dataset:
-                trajectory = []
-                for ground_atom_set in gt_traj[1]:
-                    if CFG.env == "behavior":  # pragma: no cover
-                        # In the case of behavior, we cannot directly pickle
-                        # the ground atoms dataset because the classifiers are
-                        # linked to the simulator, which cannot be pickled.
-                        # Thus, we must strip away the classifiers and replace
-                        # them with dummies.
-                        trajectory.append({
-                            GroundAtom(
-                                Predicate(atom.predicate.name,
-                                          atom.predicate.types,
-                                          lambda s, o: False), atom.entities)
-                            for atom in ground_atom_set
-                        })
-                    else:
-                        trajectory.append(ground_atom_set)
-                ground_atom_dataset_to_pkl.append(trajectory)
-            with open(dataset_fname, "wb") as f:
-                pkl.dump(ground_atom_dataset_to_pkl, f)
-            # If we're only interested in creating a training dataset, then
-            # terminate the program here and return how many demos were
-            # collected.
-            if CFG.create_training_dataset:  # pragma: no cover
-                if CFG.num_train_tasks != len(trajectories):
-                    raise AssertionError(
-                        "ERROR!: Collected only" +
-                        f"{len(trajectories)} trajectories, but needed" +
-                        f"{CFG.num_train_tasks}.")
-                raise AssertionError("SUCCESS!: Created training dataset" +
-                                     f"with {len(trajectories)} trajectories.")
+        # TODO: Create ground atom dataset to pass into subsequent
+        # functions.
+        ground_atom_dataset = behavior_utils.load_or_make_new_ground_atom_dataset(
+            trajectories, self._get_current_predicates(),
+            online_learning_cycle)
 
         self._nsrts, self._segmented_trajs, self._seg_to_nsrt = \
             learn_nsrts_from_data(trajectories,

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -15,9 +15,9 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.approaches.bilevel_planning_approach import \
     BilevelPlanningApproach
-from predicators.behavior_utils import behavior_utils
 from predicators.envs import get_or_create_env
-from predicators.nsrt_learning.nsrt_learning_main import learn_nsrts_from_data
+from predicators.nsrt_learning.nsrt_learning_main import \
+    get_ground_atoms_dataset, learn_nsrts_from_data
 from predicators.planning import task_plan, task_plan_grounding
 from predicators.settings import CFG
 from predicators.structs import NSRT, Dataset, LiftedAtom, \
@@ -66,7 +66,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
                      online_learning_cycle: Optional[int]) -> None:
-        ground_atom_dataset = behavior_utils.get_ground_atoms_dataset(
+        ground_atom_dataset = get_ground_atoms_dataset(
             trajectories, self._get_current_predicates(),
             online_learning_cycle)
 

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -5,7 +5,6 @@ or options.
 """
 
 import logging
-import os
 import re
 import time
 from typing import Dict, List, Optional, Set
@@ -18,11 +17,10 @@ from predicators.approaches.bilevel_planning_approach import \
     BilevelPlanningApproach
 from predicators.behavior_utils import behavior_utils
 from predicators.envs import get_or_create_env
-from predicators.envs.behavior import BehaviorEnv
 from predicators.nsrt_learning.nsrt_learning_main import learn_nsrts_from_data
 from predicators.planning import task_plan, task_plan_grounding
 from predicators.settings import CFG
-from predicators.structs import NSRT, Dataset, GroundAtom, LiftedAtom, \
+from predicators.structs import NSRT, Dataset, LiftedAtom, \
     LowLevelTrajectory, NSRTSampler, ParameterizedOption, Predicate, Segment, \
     Task, Type, Variable
 
@@ -68,9 +66,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
                      online_learning_cycle: Optional[int]) -> None:
-        # TODO: Create ground atom dataset to pass into subsequent
-        # functions.
-        ground_atom_dataset = behavior_utils.load_or_make_new_ground_atom_dataset(
+        ground_atom_dataset = behavior_utils.get_ground_atoms_dataset(
             trajectories, self._get_current_predicates(),
             online_learning_cycle)
 

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -1,10 +1,8 @@
 """Utility functions for using iGibson and BEHAVIOR."""
 
-import logging
 import os
 from typing import List, Optional, Sequence, Tuple, Union
 
-import dill as pkl
 import numpy as np
 import pybullet as p
 from tqdm import tqdm
@@ -596,108 +594,4 @@ def create_ground_atom_dataset_behavior(
             last_atoms = next_atoms
         ground_atom_dataset.append((traj, atoms))
         print(f"Completed {(i+1)}/{num_traj} trajectories.")
-    return ground_atom_dataset
-
-
-def get_ground_atoms_dataset(
-        trajectories: Sequence[LowLevelTrajectory], predicates: Set[Predicate],
-        online_learning_cycle: Optional[int]) -> List[GroundAtomTrajectory]:
-    """Either tries to load a saved ground atom dataset, or creates a new one
-    depending on the CFG.load_atoms flag.
-
-    If creating a new one, then save a ground atoms dataset file.
-    """
-    dataset_fname, _ = utils.create_dataset_filename_str(
-        saving_ground_atoms=True, online_learning_cycle=online_learning_cycle)
-    # If CFG.load_atoms is set, then try to create a GroundAtomTrajectory
-    # by loading sets of GroundAtoms directly from a saved file.
-    if CFG.load_atoms:
-        os.makedirs(CFG.data_dir, exist_ok=True)
-        # Check that the dataset file was previously saved.
-        if os.path.exists(dataset_fname):
-            # Load the ground atoms dataset.
-            with open(dataset_fname, "rb") as f:
-                ground_atom_dataset_atoms = pkl.load(f)
-            assert len(trajectories) == len(ground_atom_dataset_atoms)
-            logging.info("\n\nLOADED GROUND ATOM DATASET")
-
-            if CFG.env == "behavior":  # pragma: no cover
-                pred_name_to_pred = {pred.name: pred for pred in predicates}
-                new_ground_atom_dataset_atoms = []
-                # Since we save ground atoms for behavior with dummy
-                # classifiers, we need to restore the correct classifers.
-                for ground_atom_seq in ground_atom_dataset_atoms:
-                    new_ground_atom_seq = []
-                    for ground_atom_set in ground_atom_seq:
-                        new_ground_atom_set = {
-                            GroundAtom(pred_name_to_pred[atom.predicate.name],
-                                       atom.entities)
-                            for atom in ground_atom_set
-                        }
-                        new_ground_atom_seq.append(new_ground_atom_set)
-                    new_ground_atom_dataset_atoms.append(new_ground_atom_seq)
-
-            # The saved ground atom dataset consists only of sequences
-            # of sets of GroundAtoms, we need to recombine this with
-            # the LowLevelTrajectories to create a GroundAtomTrajectory.
-            ground_atom_dataset = []
-            for i, traj in enumerate(trajectories):
-                if CFG.env == "behavior":
-                    ground_atom_seq = new_ground_atom_dataset_atoms[
-                        i]  # pragma: no cover
-                else:
-                    ground_atom_seq = ground_atom_dataset_atoms[i]
-                ground_atom_dataset.append(
-                    (traj, [set(atoms) for atoms in ground_atom_seq]))
-        else:
-            raise ValueError(f"Cannot load ground atoms: {dataset_fname}")
-    else:
-        # Apply predicates to data, producing a dataset of abstract states.
-        if CFG.env == "behavior":  # pragma: no cover
-            from predicators.envs import get_or_create_env
-            env = get_or_create_env("behavior")
-            assert isinstance(env, BehaviorEnv)
-            ground_atom_dataset = \
-                create_ground_atom_dataset_behavior(
-                    trajectories, predicates, env)
-        else:
-            ground_atom_dataset = utils.create_ground_atom_dataset(
-                trajectories, predicates)
-        # Save ground atoms dataset to file. Note that a
-        # GroundAtomTrajectory contains a normal LowLevelTrajectory and a
-        # list of sets of GroundAtoms, so we only save the list of
-        # GroundAtoms (the LowLevelTrajectories are saved separately).
-        ground_atom_dataset_to_pkl = []
-        for gt_traj in ground_atom_dataset:
-            trajectory = []
-            for ground_atom_set in gt_traj[1]:
-                if CFG.env == "behavior":  # pragma: no cover
-                    # In the case of behavior, we cannot directly pickle
-                    # the ground atoms dataset because the classifiers are
-                    # linked to the simulator, which cannot be pickled.
-                    # Thus, we must strip away the classifiers and replace
-                    # them with dummies.
-                    trajectory.append({
-                        GroundAtom(
-                            Predicate(atom.predicate.name,
-                                      atom.predicate.types,
-                                      lambda s, o: False), atom.entities)
-                        for atom in ground_atom_set
-                    })
-                else:
-                    trajectory.append(ground_atom_set)
-            ground_atom_dataset_to_pkl.append(trajectory)
-        with open(dataset_fname, "wb") as f:
-            pkl.dump(ground_atom_dataset_to_pkl, f)
-        # If we're only interested in creating a training dataset, then
-        # terminate the program here and return how many demos were
-        # collected.
-        if CFG.create_training_dataset:  # pragma: no cover
-            if CFG.num_train_tasks != len(trajectories):
-                raise AssertionError(
-                    "ERROR!: Collected only" +
-                    f"{len(trajectories)} trajectories, but needed" +
-                    f"{CFG.num_train_tasks}.")
-            raise AssertionError("SUCCESS!: Created training dataset" +
-                                 f"with {len(trajectories)} trajectories.")
     return ground_atom_dataset

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -5,12 +5,14 @@ from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pybullet as p
+import logging
 from tqdm import tqdm
+import dill as pkl
 
 from predicators.settings import CFG
 from predicators.structs import Array, GroundAtom, GroundAtomTrajectory, \
     LowLevelTrajectory, Predicate, Set, State
-from predicators.utils import abstract, abstract_from_last
+from predicators import utils
 
 try:
     from igibson.envs.behavior_env import \
@@ -579,19 +581,123 @@ def create_ground_atom_dataset_behavior(
         atoms = []
         first_state = True
         for s in tqdm(traj.states):
-            # If th environment is BEHAVIOR we need to load the state before
+            # If the environment is BEHAVIOR we need to load the state before
             # we call the predicate classifiers.
             load_checkpoint_state(s, env)
             if not use_last_state or first_state:
-                next_atoms = abstract(s, predicates)
+                next_atoms = utils.abstract(s, predicates)
                 first_state = False
             else:
                 # Get atoms from last abstract state and state change
-                next_atoms = abstract_from_last(s, predicates, last_s,
+                next_atoms = utils.abstract_from_last(s, predicates, last_s,
                                                 last_atoms)
             atoms.append(next_atoms)
             last_s = s
             last_atoms = next_atoms
         ground_atom_dataset.append((traj, atoms))
         print(f"Completed {(i+1)}/{num_traj} trajectories.")
+    return ground_atom_dataset
+
+
+def load_or_make_new_ground_atom_dataset(
+        trajectories: Sequence[LowLevelTrajectory], predicates: Set[Predicate],
+        online_learning_cycle: Optional[int]) -> List[GroundAtomTrajectory]:
+    """Either tries to load a saved ground atom dataset, or creates a new one
+    depending on the CFG.load_atoms flag.
+
+    If creating a new one, then save a ground atoms dataset file.
+    """
+    dataset_fname, _ = utils.create_dataset_filename_str(
+        saving_ground_atoms=True, online_learning_cycle=online_learning_cycle)
+    # If CFG.load_atoms is set, then try to create a GroundAtomTrajectory
+    # by loading sets of GroundAtoms directly from a saved file.
+    if CFG.load_atoms:
+        os.makedirs(CFG.data_dir, exist_ok=True)
+        # Check that the dataset file was previously saved.
+        if os.path.exists(dataset_fname):
+            # Load the ground atoms dataset.
+            with open(dataset_fname, "rb") as f:
+                ground_atom_dataset_atoms = pkl.load(f)
+            assert len(trajectories) == len(ground_atom_dataset_atoms)
+            logging.info("\n\nLOADED GROUND ATOM DATASET")
+
+            if CFG.env == "behavior":  # pragma: no cover
+                pred_name_to_pred = {pred.name: pred for pred in predicates}
+                new_ground_atom_dataset_atoms = []
+                # Since we save ground atoms for behavior with dummy
+                # classifiers, we need to restore the correct classifers.
+                for ground_atom_seq in ground_atom_dataset_atoms:
+                    new_ground_atom_seq = []
+                    for ground_atom_set in ground_atom_seq:
+                        new_ground_atom_set = {
+                            GroundAtom(pred_name_to_pred[atom.predicate.name],
+                                       atom.entities)
+                            for atom in ground_atom_set
+                        }
+                        new_ground_atom_seq.append(new_ground_atom_set)
+                    new_ground_atom_dataset_atoms.append(new_ground_atom_seq)
+
+            # The saved ground atom dataset consists only of sequences
+            # of sets of GroundAtoms, we need to recombine this with
+            # the LowLevelTrajectories to create a GroundAtomTrajectory.
+            ground_atom_dataset = []
+            for i, traj in enumerate(trajectories):
+                if CFG.env == "behavior":
+                    ground_atom_seq = new_ground_atom_dataset_atoms[
+                        i]  # pragma: no cover
+                else:
+                    ground_atom_seq = ground_atom_dataset_atoms[i]
+                ground_atom_dataset.append(
+                    (traj, [set(atoms) for atoms in ground_atom_seq]))
+        else:
+            raise ValueError(f"Cannot load ground atoms: {dataset_fname}")
+    else:
+        # Apply predicates to data, producing a dataset of abstract states.
+        if CFG.env == "behavior":  # pragma: no cover
+            from predicators.envs import get_or_create_env
+            env = get_or_create_env("behavior")
+            assert isinstance(env, BehaviorEnv)
+            ground_atom_dataset = \
+                create_ground_atom_dataset_behavior(
+                    trajectories, predicates, env)
+        else:
+            ground_atom_dataset = utils.create_ground_atom_dataset(
+                trajectories, predicates)
+        # Save ground atoms dataset to file. Note that a
+        # GroundAtomTrajectory contains a normal LowLevelTrajectory and a
+        # list of sets of GroundAtoms, so we only save the list of
+        # GroundAtoms (the LowLevelTrajectories are saved separately).
+        ground_atom_dataset_to_pkl = []
+        for gt_traj in ground_atom_dataset:
+            trajectory = []
+            for ground_atom_set in gt_traj[1]:
+                if CFG.env == "behavior":  # pragma: no cover
+                    # In the case of behavior, we cannot directly pickle
+                    # the ground atoms dataset because the classifiers are
+                    # linked to the simulator, which cannot be pickled.
+                    # Thus, we must strip away the classifiers and replace
+                    # them with dummies.
+                    trajectory.append({
+                        GroundAtom(
+                            Predicate(atom.predicate.name,
+                                      atom.predicate.types,
+                                      lambda s, o: False), atom.entities)
+                        for atom in ground_atom_set
+                    })
+                else:
+                    trajectory.append(ground_atom_set)
+            ground_atom_dataset_to_pkl.append(trajectory)
+        with open(dataset_fname, "wb") as f:
+            pkl.dump(ground_atom_dataset_to_pkl, f)
+        # If we're only interested in creating a training dataset, then
+        # terminate the program here and return how many demos were
+        # collected.
+        if CFG.create_training_dataset:  # pragma: no cover
+            if CFG.num_train_tasks != len(trajectories):
+                raise AssertionError(
+                    "ERROR!: Collected only" +
+                    f"{len(trajectories)} trajectories, but needed" +
+                    f"{CFG.num_train_tasks}.")
+            raise AssertionError("SUCCESS!: Created training dataset" +
+                                 f"with {len(trajectories)} trajectories.")
     return ground_atom_dataset

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -1,18 +1,18 @@
 """Utility functions for using iGibson and BEHAVIOR."""
 
+import logging
 import os
 from typing import List, Optional, Sequence, Tuple, Union
 
+import dill as pkl
 import numpy as np
 import pybullet as p
-import logging
 from tqdm import tqdm
-import dill as pkl
 
+from predicators import utils
 from predicators.settings import CFG
 from predicators.structs import Array, GroundAtom, GroundAtomTrajectory, \
     LowLevelTrajectory, Predicate, Set, State
-from predicators import utils
 
 try:
     from igibson.envs.behavior_env import \
@@ -590,7 +590,7 @@ def create_ground_atom_dataset_behavior(
             else:
                 # Get atoms from last abstract state and state change
                 next_atoms = utils.abstract_from_last(s, predicates, last_s,
-                                                last_atoms)
+                                                      last_atoms)
             atoms.append(next_atoms)
             last_s = s
             last_atoms = next_atoms
@@ -599,7 +599,7 @@ def create_ground_atom_dataset_behavior(
     return ground_atom_dataset
 
 
-def load_or_make_new_ground_atom_dataset(
+def get_ground_atoms_dataset(
         trajectories: Sequence[LowLevelTrajectory], predicates: Set[Predicate],
         online_learning_cycle: Optional[int]) -> List[GroundAtomTrajectory]:
     """Either tries to load a saved ground atom dataset, or creates a new one

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Collection, Dict, \
 from typing import Type as TypingType
 from typing import TypeVar, Union, cast
 
+import dill as pkl
 import imageio
 import matplotlib
 import matplotlib.pyplot as plt

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Collection, Dict, \
 from typing import Type as TypingType
 from typing import TypeVar, Union, cast
 
-import dill as pkl
 import imageio
 import matplotlib
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This PR (1) moves the creation of a ground atoms dataset into its own function, and (2) calls this function both from STRIPS learning approaches and the GNN shooting approach.

Previously, the `--load_atoms` flag had no effect when learning GNN's. Now, we can learn GNN's from saved atoms datasets.