### PR TITLE
fix graphify error

### DIFF
--- a/predicators/approaches/gnn_approach.py
+++ b/predicators/approaches/gnn_approach.py
@@ -430,7 +430,8 @@ class GNNApproach(BaseApproach, Generic[_Output]):
 
         ## Add node features for unary atoms.
         for atom in atoms:
-            if atom.predicate.arity != 1:
+            if atom.predicate.arity != 1 or atom.predicate not in self._node_feature_to_index[
+                    atom.predicate]:
                 continue
             obj_index = object_to_node[atom.objects[0]]
             atom_index = self._node_feature_to_index[atom.predicate]
@@ -462,7 +463,7 @@ class GNNApproach(BaseApproach, Generic[_Output]):
 
         ## Add edge features for binary atoms.
         for atom in atoms:
-            if atom.predicate.arity != 2:
+            if atom.predicate.arity != 2 or atom.predicate not in self._edge_feature_to_index:
                 continue
             pred_index = self._edge_feature_to_index[atom.predicate]
             obj0_index = object_to_node[atom.objects[0]]
@@ -471,7 +472,8 @@ class GNNApproach(BaseApproach, Generic[_Output]):
 
         ## Add edge features for reversed binary atoms.
         for atom in atoms:
-            if atom.predicate.arity != 2:
+            if atom.predicate.arity != 2 or R(
+                    atom.predicate) not in self._edge_feature_to_index:
                 continue
             pred_index = self._edge_feature_to_index[R(atom.predicate)]
             obj0_index = object_to_node[atom.objects[0]]

--- a/predicators/approaches/gnn_approach.py
+++ b/predicators/approaches/gnn_approach.py
@@ -408,12 +408,12 @@ class GNNApproach(BaseApproach, Generic[_Output]):
         # Input globals: nullary predicates in atoms and goal.
         atoms_globals = np.zeros(len(self._nullary_predicates), dtype=np.int64)
         for atom in atoms:
-            if atom.predicate.arity != 0:
+            if atom.predicate.arity != 0 or atom.predicate not in self._nullary_predicates:
                 continue
             atoms_globals[self._nullary_predicates.index(atom.predicate)] = 1
         goal_globals = np.zeros(len(self._nullary_predicates), dtype=np.int64)
         for atom in goal:
-            if atom.predicate.arity != 0:
+            if atom.predicate.arity != 0 or atom.predicate not in self._nullary_predicates:
                 continue
             goal_globals[self._nullary_predicates.index(atom.predicate)] = 1
         graph["globals"] = np.r_[atoms_globals, goal_globals]
@@ -439,7 +439,8 @@ class GNNApproach(BaseApproach, Generic[_Output]):
 
         ## Add node features for unary atoms in goal.
         for atom in goal:
-            if atom.predicate.arity != 1:
+            if atom.predicate.arity != 1 or G(
+                    atom.predicate) not in self._node_feature_to_index:
                 continue
             obj_index = object_to_node[atom.objects[0]]
             atom_index = self._node_feature_to_index[G(atom.predicate)]
@@ -484,7 +485,8 @@ class GNNApproach(BaseApproach, Generic[_Output]):
 
         ## Add edge features for binary atoms in goal.
         for atom in goal:
-            if atom.predicate.arity != 2:
+            if atom.predicate.arity != 2 or G(
+                    atom.predicate) not in self._edge_feature_to_index:
                 continue
             pred_index = self._edge_feature_to_index[G(atom.predicate)]
             obj0_index = object_to_node[atom.objects[0]]
@@ -493,7 +495,8 @@ class GNNApproach(BaseApproach, Generic[_Output]):
 
         ## Add edge features for reversed binary atoms in goal.
         for atom in goal:
-            if atom.predicate.arity != 2:
+            if atom.predicate.arity != 2 or G(R(
+                    atom.predicate)) not in self._edge_feature_to_index:
                 continue
             pred_index = self._edge_feature_to_index[G(R(atom.predicate))]
             obj0_index = object_to_node[atom.objects[0]]

--- a/predicators/approaches/gnn_approach.py
+++ b/predicators/approaches/gnn_approach.py
@@ -408,12 +408,14 @@ class GNNApproach(BaseApproach, Generic[_Output]):
         # Input globals: nullary predicates in atoms and goal.
         atoms_globals = np.zeros(len(self._nullary_predicates), dtype=np.int64)
         for atom in atoms:
-            if atom.predicate.arity != 0 or atom.predicate not in self._nullary_predicates:
+            if atom.predicate.arity != 0 or atom.predicate not in \
+                self._nullary_predicates: # pragma: no cover
                 continue
             atoms_globals[self._nullary_predicates.index(atom.predicate)] = 1
         goal_globals = np.zeros(len(self._nullary_predicates), dtype=np.int64)
         for atom in goal:
-            if atom.predicate.arity != 0 or atom.predicate not in self._nullary_predicates:
+            if atom.predicate.arity != 0 or atom.predicate not in \
+                self._nullary_predicates: # pragma: no cover
                 continue
             goal_globals[self._nullary_predicates.index(atom.predicate)] = 1
         graph["globals"] = np.r_[atoms_globals, goal_globals]
@@ -431,7 +433,7 @@ class GNNApproach(BaseApproach, Generic[_Output]):
         ## Add node features for unary atoms.
         for atom in atoms:
             if atom.predicate.arity != 1 or atom.predicate not in \
-                self._node_feature_to_index:
+                self._node_feature_to_index: # pragma: no cover
                 continue
             obj_index = object_to_node[atom.objects[0]]
             atom_index = self._node_feature_to_index[atom.predicate]
@@ -441,7 +443,7 @@ class GNNApproach(BaseApproach, Generic[_Output]):
         for atom in goal:
             if atom.predicate.arity != 1 or G(
                     atom.predicate) not in self._node_feature_to_index:
-                continue
+                continue  # pragma: no cover
             obj_index = object_to_node[atom.objects[0]]
             atom_index = self._node_feature_to_index[G(atom.predicate)]
             node_features[obj_index, atom_index] = 1
@@ -466,7 +468,7 @@ class GNNApproach(BaseApproach, Generic[_Output]):
         for atom in atoms:
             if atom.predicate.arity != 2 or atom.predicate not in \
                 self._edge_feature_to_index:
-                continue
+                continue  # pragma: no cover
             pred_index = self._edge_feature_to_index[atom.predicate]
             obj0_index = object_to_node[atom.objects[0]]
             obj1_index = object_to_node[atom.objects[1]]
@@ -476,7 +478,7 @@ class GNNApproach(BaseApproach, Generic[_Output]):
         for atom in atoms:
             if atom.predicate.arity != 2 or R(
                     atom.predicate) not in self._edge_feature_to_index:
-                continue
+                continue  # pragma: no cover
             pred_index = self._edge_feature_to_index[R(atom.predicate)]
             obj0_index = object_to_node[atom.objects[0]]
             obj1_index = object_to_node[atom.objects[1]]
@@ -487,7 +489,7 @@ class GNNApproach(BaseApproach, Generic[_Output]):
         for atom in goal:
             if atom.predicate.arity != 2 or G(
                     atom.predicate) not in self._edge_feature_to_index:
-                continue
+                continue  # pragma: no cover
             pred_index = self._edge_feature_to_index[G(atom.predicate)]
             obj0_index = object_to_node[atom.objects[0]]
             obj1_index = object_to_node[atom.objects[1]]
@@ -497,7 +499,7 @@ class GNNApproach(BaseApproach, Generic[_Output]):
         for atom in goal:
             if atom.predicate.arity != 2 or G(R(
                     atom.predicate)) not in self._edge_feature_to_index:
-                continue
+                continue  # pragma: no cover
             pred_index = self._edge_feature_to_index[G(R(atom.predicate))]
             obj0_index = object_to_node[atom.objects[0]]
             obj1_index = object_to_node[atom.objects[1]]

--- a/predicators/approaches/gnn_approach.py
+++ b/predicators/approaches/gnn_approach.py
@@ -430,8 +430,8 @@ class GNNApproach(BaseApproach, Generic[_Output]):
 
         ## Add node features for unary atoms.
         for atom in atoms:
-            if atom.predicate.arity != 1 or atom.predicate not in self._node_feature_to_index[
-                    atom.predicate]:
+            if atom.predicate.arity != 1 or atom.predicate not in \
+                self._node_feature_to_index:
                 continue
             obj_index = object_to_node[atom.objects[0]]
             atom_index = self._node_feature_to_index[atom.predicate]
@@ -463,7 +463,8 @@ class GNNApproach(BaseApproach, Generic[_Output]):
 
         ## Add edge features for binary atoms.
         for atom in atoms:
-            if atom.predicate.arity != 2 or atom.predicate not in self._edge_feature_to_index:
+            if atom.predicate.arity != 2 or atom.predicate not in \
+                self._edge_feature_to_index:
                 continue
             pred_index = self._edge_feature_to_index[atom.predicate]
             obj0_index = object_to_node[atom.objects[0]]


### PR DESCRIPTION
Previously, there was this corner case where we would throw an `IndexError` if we saw a predicate that we didn't see at training time. This noew fixes this by simply skipping over these predicates.