### PR TITLE
Fixes bug arising from using `task_num` instead of `task_instance_id`

### DIFF
--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -59,7 +59,8 @@ class BilevelPlanningApproach(BaseApproach):
             assert isinstance(env, BehaviorEnv)
             if not task.init.allclose(
                     env.current_ig_state_to_state(
-                        save_state=False, use_test_scene=env.task_num >= 10)):
+                        save_state=False,
+                        use_test_scene=env.task_instance_id >= 10)):
                 load_checkpoint_state(task.init, env)
 
         nsrts = self._get_current_nsrts()

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -590,7 +590,7 @@ def load_checkpoint_state(s: State,
         env.igibson_behavior_env.simulator.frame_count = frame_count
         env.set_options()
         env.current_ig_state_to_state(
-            use_test_scene=env.task_num >=
+            use_test_scene=env.task_instance_id >=
             10)  # overwrite the old task_init checkpoint file!
         env.igibson_behavior_env.reset()
     behavior_task_name = CFG.behavior_task_list[0] if len(
@@ -599,7 +599,7 @@ def load_checkpoint_state(s: State,
     # tasks must have a task num below 10 and test tasks must have one
     # above 10. This is sketchy in general and we should probably come
     # up with something cleaner!
-    if env.task_num < 10:
+    if env.task_instance_id < 10:
         scene_name = CFG.behavior_train_scene_name
     else:
         scene_name = CFG.behavior_test_scene_name

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -242,7 +242,7 @@ class BehaviorEnv(BaseEnv):
                 angularVelocity=[0, 0, 0],
             )
         next_state = self.current_ig_state_to_state(
-            use_test_scene=self.task_num >= 10)
+            use_test_scene=self.task_instance_id >= 10)
         return next_state
 
     def _generate_train_tasks(self) -> List[Task]:
@@ -691,7 +691,8 @@ class BehaviorEnv(BaseEnv):
             return
         if not state.allclose(
                 self.current_ig_state_to_state(
-                    save_state=False, use_test_scene=self.task_num >= 10)):
+                    save_state=False,
+                    use_test_scene=self.task_instance_id >= 10)):
             load_checkpoint_state(state, self)
 
     def _reachable_classifier(self, state: State,

--- a/predicators/option_model.py
+++ b/predicators/option_model.py
@@ -144,12 +144,13 @@ class _BehaviorOptionModel(_OptionModelBase):
         if not CFG.plan_only_eval:
             if not state.allclose(
                     env.current_ig_state_to_state(
-                        save_state=False, use_test_scene=env.task_num >= 10)):
+                        save_state=False,
+                        use_test_scene=env.task_instance_id >= 10)):
                 load_checkpoint_state(state, env, reset=True)
         option.memory["model_controller"](state, env.igibson_behavior_env)
         # next_state = env.current_ig_state_to_state()
         next_state = env.current_ig_state_to_state(
-            use_test_scene=env.task_num >= 10)
+            use_test_scene=env.task_instance_id >= 10)
         plan, _ = option.memory["planner_result"]
         return next_state, len(plan)
 
@@ -161,4 +162,5 @@ class _BehaviorOptionModel(_OptionModelBase):
         assert isinstance(env, BehaviorEnv)
         load_checkpoint_state(state, env)
         # return env.current_ig_state_to_state()
-        return env.current_ig_state_to_state(use_test_scene=env.task_num >= 10)
+        return env.current_ig_state_to_state(
+            use_test_scene=env.task_instance_id >= 10)


### PR DESCRIPTION
Previously, the code was mistakenly using `env.task_num` to decide whether to use the test scene or the training scene. This PR switches this to use the `env.task_instance_id`!