### PR TITLE
fix 0 length trajectory

### DIFF
--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -46,7 +46,8 @@ class GNNOptionPolicyApproach(GNNApproach):
     ) -> List[Tuple[State, Set[GroundAtom], Set[GroundAtom], _Option]]:
         data = []
         ground_atom_dataset = get_ground_atoms_dataset(
-            dataset.trajectories, self._initial_predicates, None)
+            dataset.trajectories, self._initial_predicates, None,
+            self._train_tasks)
         # In this approach, we never learned any NSRTs, so we just call
         # segment_trajectory() to segment the given dataset.
         segmented_trajs = [

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -68,7 +68,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
                      online_learning_cycle: Optional[int]) -> None:
         ground_atom_dataset = get_ground_atoms_dataset(
             trajectories, self._get_current_predicates(),
-            online_learning_cycle)
+            online_learning_cycle, self._train_tasks)
 
         self._nsrts, self._segmented_trajs, self._seg_to_nsrt = \
             learn_nsrts_from_data(trajectories,

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 from predicators import utils
 from predicators.settings import CFG
 from predicators.structs import Array, GroundAtom, GroundAtomTrajectory, \
-    LowLevelTrajectory, Predicate, Set, State
+    LowLevelTrajectory, Predicate, Set, State, Task
 
 try:
     from igibson.envs.behavior_env import \
@@ -628,9 +628,13 @@ def create_ground_atom_dataset_behavior(
     trajectories: Sequence[LowLevelTrajectory],
     predicates: Set[Predicate],
     env: "BehaviorEnv",
-    use_last_state: bool = True
+    train_tasks: List[Task],
+    use_last_state: bool = False
 ) -> List[GroundAtomTrajectory]:  # pragma: no cover
     """Apply all predicates to all trajectories in the dataset."""
+    # NOTE: setting use_last_state to True is potentially
+    # dangerous (especially if the task involves opening/closing
+    # things). There is currently an issue open to try to resolve this.
     ground_atom_dataset = []
     num_traj = len(trajectories)
     for i, traj in enumerate(trajectories):
@@ -653,5 +657,19 @@ def create_ground_atom_dataset_behavior(
             last_s = s
             last_atoms = next_atoms
         ground_atom_dataset.append((traj, atoms))
+        # Assert here that traj goal is a subset of the final atoms in
+        # each trajectory.
+        if traj.is_demo:
+            try:
+                assert train_tasks[traj.train_task_idx].goal.issubset(
+                    last_atoms)
+            except AssertionError as e:
+                missing_atoms = train_tasks[
+                    traj.train_task_idx].goal - last_atoms
+                print("Train task goal not achieved by demonstration. " +
+                      f"Discrepancy: {missing_atoms}")
+                import ipdb
+                ipdb.set_trace()
+                raise e
         print(f"Completed {(i+1)}/{num_traj} trajectories.")
     return ground_atom_dataset

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -663,13 +663,11 @@ def create_ground_atom_dataset_behavior(
             try:
                 assert train_tasks[traj.train_task_idx].goal.issubset(
                     last_atoms)
-            except AssertionError as e:
+            except AssertionError as err:
                 missing_atoms = train_tasks[
                     traj.train_task_idx].goal - last_atoms
                 print("Train task goal not achieved by demonstration. " +
                       f"Discrepancy: {missing_atoms}")
-                import ipdb
-                ipdb.set_trace()
-                raise e
+                raise err
         print(f"Completed {(i+1)}/{num_traj} trajectories.")
     return ground_atom_dataset

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -257,7 +257,7 @@ class BehaviorEnv(BaseEnv):
                    num: int,
                    rng: np.random.Generator,
                    testing: bool = False) -> List[Task]:
-        tasks = []
+        tasks: List[Task] = []
         while len(tasks) < num:
             # BEHAVIOR uses np.random everywhere. This is a somewhat
             # hacky workaround for that.

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -258,7 +258,7 @@ class BehaviorEnv(BaseEnv):
                    rng: np.random.Generator,
                    testing: bool = False) -> List[Task]:
         tasks = []
-        for _ in range(num):
+        while len(tasks) < num:
             # BEHAVIOR uses np.random everywhere. This is a somewhat
             # hacky workaround for that.
             curr_env_seed = rng.integers(0, (2**32) - 1)
@@ -332,8 +332,11 @@ class BehaviorEnv(BaseEnv):
                 self.igibson_behavior_env.step(
                     np.zeros(self.igibson_behavior_env.action_space.shape))
             init_state = self.current_ig_state_to_state(use_test_scene=testing)
-            goal = self._get_task_goal()
+            goal = self._get_task_goal()            
             task = Task(init_state, goal)
+            # If the goal already happens to hold in the init state, then resample.
+            if task.goal_holds(init_state):
+                continue
             tasks.append(task)
             self.task_num += 1
 

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -334,7 +334,8 @@ class BehaviorEnv(BaseEnv):
             init_state = self.current_ig_state_to_state(use_test_scene=testing)
             goal = self._get_task_goal()
             task = Task(init_state, goal)
-            # If the goal already happens to hold in the init state, then resample.
+            # If the goal already happens to hold in the init state, then
+            # resample.
             if task.goal_holds(init_state):
                 continue
             tasks.append(task)

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -332,7 +332,7 @@ class BehaviorEnv(BaseEnv):
                 self.igibson_behavior_env.step(
                     np.zeros(self.igibson_behavior_env.action_space.shape))
             init_state = self.current_ig_state_to_state(use_test_scene=testing)
-            goal = self._get_task_goal()            
+            goal = self._get_task_goal()
             task = Task(init_state, goal)
             # If the goal already happens to hold in the init state, then resample.
             if task.goal_holds(init_state):

--- a/predicators/nsrt_learning/nsrt_learning_main.py
+++ b/predicators/nsrt_learning/nsrt_learning_main.py
@@ -141,7 +141,8 @@ def learn_nsrts_from_data(
 
 def get_ground_atoms_dataset(
         trajectories: Sequence[LowLevelTrajectory], predicates: Set[Predicate],
-        online_learning_cycle: Optional[int]) -> List[GroundAtomTrajectory]:
+        online_learning_cycle: Optional[int],
+        train_tasks: List[Task]) -> List[GroundAtomTrajectory]:
     """Either tries to load a saved ground atom dataset, or creates a new one
     depending on the CFG.load_atoms flag.
 
@@ -198,7 +199,7 @@ def get_ground_atoms_dataset(
             assert isinstance(env, behavior.BehaviorEnv)
             ground_atom_dataset = \
                 behavior_utils.create_ground_atom_dataset_behavior(
-                    trajectories, predicates, env)
+                    trajectories, predicates, env, train_tasks)
         else:
             ground_atom_dataset = utils.create_ground_atom_dataset(
                 trajectories, predicates)


### PR DESCRIPTION
Previously, we sometimes generated trajs with length 0 because we would sample tasks where the goal already holds true in the initial state. This PR changes BEHAVIOR task sampling to fix that.