### PR TITLE
Fast grounding fix handempty

### DIFF
--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -650,7 +650,7 @@ def create_ground_atom_dataset_behavior(
             if not use_last_state or first_state:
                 next_atoms = utils.abstract(s,
                                             predicates,
-                                            skip_allclose_check=False)
+                                            skip_allclose_check=True)
                 first_state = False
             else:
                 # Get atoms from last abstract state and state change

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -1784,7 +1784,9 @@ def abstract_from_last(
     # Computes predicates for atoms with objects whose state has changed.
     for pred in preds:
         for choice in get_object_combinations(list(state), pred.types):
-            if any(obj in changed_objs for obj in choice) or ("reachable" in pred.name and agent_changed) or ("openable" in pred.name) or ("handempty" in pred.name):
+            if any(obj in changed_objs for obj in choice) or (
+                    "reachable" in pred.name and agent_changed) or (
+                        "openable" in pred.name) or ("handempty" in pred.name):
                 if pred.holds(state,
                               choice,
                               skip_allclose_check=skip_allclose_check):

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -1778,15 +1778,13 @@ def abstract_from_last(
     for atom in last_atoms:
         if all(obj not in changed_objs for obj in atom.objects):
             if not ("reachable" in atom.predicate.name and agent_changed) \
-                and (not "openable" in atom.predicate.name):
+                and (not "openable" in atom.predicate.name) \
+                and (not "handempty" in atom.predicate.name):
                 atoms.add(atom)
     # Computes predicates for atoms with objects whose state has changed.
     for pred in preds:
         for choice in get_object_combinations(list(state), pred.types):
-            if any(obj in changed_objs
-                   for obj in choice) or ("reachable" in pred.name
-                                          and agent_changed) or ("openable"
-                                                                 in pred.name):
+            if any(obj in changed_objs for obj in choice) or ("reachable" in pred.name and agent_changed) or ("openable" in pred.name) or ("handempty" in pred.name):
                 if pred.holds(state,
                               choice,
                               skip_allclose_check=skip_allclose_check):


### PR DESCRIPTION
Previously, we didn't correctly ground the `handempty` predicate during fast grounding because we kept passing it thru without actually re-checking it...