### PR TITLE
GNN + minor changes needed to get `sorting-books` working

### DIFF
--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -250,7 +250,7 @@ class GNNOptionPolicyApproach(GNNApproach):
                              timeout: int) -> Callable[[State], Action]:
         start_time = time.perf_counter()
         memory: Dict = {}  # optionally updated by predict()
-        if CFG.env == 'behavior':
+        if CFG.env == 'behavior':  # pragma: no cover
             # Be sure to reload the behavior env to get the correct one.
             curr_behavior_env = get_or_create_env('behavior')
             load_checkpoint_state(task.init, curr_behavior_env, reset=True)

--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -14,6 +14,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.approaches import ApproachFailure, ApproachTimeout
 from predicators.approaches.gnn_approach import GNNApproach
+from predicators.behavior_utils.behavior_utils import load_checkpoint_state
+from predicators.envs import get_or_create_env
 from predicators.nsrt_learning.nsrt_learning_main import \
     get_ground_atoms_dataset
 from predicators.nsrt_learning.segmentation import segment_trajectory
@@ -22,8 +24,6 @@ from predicators.settings import CFG
 from predicators.structs import Action, Array, Dataset, DummyOption, \
     GroundAtom, Object, ParameterizedOption, Predicate, State, Task, Type, \
     _Option
-from predicators.envs import get_or_create_env
-from predicators.behavior_utils.behavior_utils import load_checkpoint_state
 
 
 class GNNOptionPolicyApproach(GNNApproach):

--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -22,6 +22,8 @@ from predicators.settings import CFG
 from predicators.structs import Action, Array, Dataset, DummyOption, \
     GroundAtom, Object, ParameterizedOption, Predicate, State, Task, Type, \
     _Option
+from predicators.envs import get_or_create_env
+from predicators.behavior_utils.behavior_utils import load_checkpoint_state
 
 
 class GNNOptionPolicyApproach(GNNApproach):
@@ -205,6 +207,9 @@ class GNNOptionPolicyApproach(GNNApproach):
         # implemented. Thus, we must use the option model and setup
         # self._last_traj and self._last_plan.
         state = task.init
+        # Be sure to reload the behavior env to get the correct one.
+        curr_behavior_env = get_or_create_env('behavior')
+        load_checkpoint_state(state, curr_behavior_env, reset=True)
         total_num_act = 0
         plan: List[_Option] = []
         start_time = time.perf_counter()
@@ -245,6 +250,10 @@ class GNNOptionPolicyApproach(GNNApproach):
                              timeout: int) -> Callable[[State], Action]:
         start_time = time.perf_counter()
         memory: Dict = {}  # optionally updated by predict()
+        if CFG.env == 'behavior':
+            # Be sure to reload the behavior env to get the correct one.
+            curr_behavior_env = get_or_create_env('behavior')
+            load_checkpoint_state(task.init, curr_behavior_env, reset=True)
         # Keep trying until the timeout.
         while time.perf_counter() - start_time < timeout:
             total_num_act = 0

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -739,7 +739,7 @@ def create_ground_atom_dataset_behavior(
                 atoms[-1] |= missing_atoms
                 print(train_tasks[traj.train_task_idx].goal.issubset(
                     last_atoms))
-                import ipdb; ipdb.set_trace()
+                #import ipdb; ipdb.set_trace()
                 
                 # raise err
         print(f"Completed {(i+1)}/{num_traj} trajectories.")

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -714,12 +714,6 @@ def create_ground_atom_dataset_behavior(
                                                       last_s,
                                                       last_atoms,
                                                       skip_allclose_check=True)
-            # HACK to try to fix weird discrepancy bug
-            if len(atoms) == len(traj.states) - 1:
-                next_atoms = utils.abstract(s,
-                                            predicates,
-                                            skip_allclose_check=True)
-            
             atoms.append(next_atoms)
             last_s = s
             last_atoms = next_atoms
@@ -734,13 +728,7 @@ def create_ground_atom_dataset_behavior(
                 missing_atoms = train_tasks[
                     traj.train_task_idx].goal - last_atoms
                 print("Train task goal not achieved by demonstration. " +
-                      f"Discrepancy: {missing_atoms}")
-                last_atoms |= missing_atoms
-                atoms[-1] |= missing_atoms
-                print(train_tasks[traj.train_task_idx].goal.issubset(
-                    last_atoms))
-                #import ipdb; ipdb.set_trace()
-                
-                # raise err
+                      f"Discrepancy: {missing_atoms}")                
+                raise err
         print(f"Completed {(i+1)}/{num_traj} trajectories.")
     return ground_atom_dataset

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -728,7 +728,7 @@ def create_ground_atom_dataset_behavior(
                 missing_atoms = train_tasks[
                     traj.train_task_idx].goal - last_atoms
                 print("Train task goal not achieved by demonstration. " +
-                      f"Discrepancy: {missing_atoms}")                
+                      f"Discrepancy: {missing_atoms}")
                 raise err
         print(f"Completed {(i+1)}/{num_traj} trajectories.")
     return ground_atom_dataset

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -714,6 +714,12 @@ def create_ground_atom_dataset_behavior(
                                                       last_s,
                                                       last_atoms,
                                                       skip_allclose_check=True)
+            # HACK to try to fix weird discrepancy bug
+            if len(atoms) == len(traj.states) - 1:
+                next_atoms = utils.abstract(s,
+                                            predicates,
+                                            skip_allclose_check=True)
+            
             atoms.append(next_atoms)
             last_s = s
             last_atoms = next_atoms
@@ -729,6 +735,12 @@ def create_ground_atom_dataset_behavior(
                     traj.train_task_idx].goal - last_atoms
                 print("Train task goal not achieved by demonstration. " +
                       f"Discrepancy: {missing_atoms}")
-                raise err
+                last_atoms |= missing_atoms
+                atoms[-1] |= missing_atoms
+                print(train_tasks[traj.train_task_idx].goal.issubset(
+                    last_atoms))
+                import ipdb; ipdb.set_trace()
+                
+                # raise err
         print(f"Completed {(i+1)}/{num_traj} trajectories.")
     return ground_atom_dataset

--- a/predicators/option_model.py
+++ b/predicators/option_model.py
@@ -146,6 +146,10 @@ class _BehaviorOptionModel(_OptionModelBase):
                     env.current_ig_state_to_state(
                         save_state=False,
                         use_test_scene=env.task_instance_id >= 10)):
+                # Since GNN approaches call the option model a large
+                # number of times during eval, setting reset to True
+                # actually causes the pybullet physics sim inside
+                # iGibson to freak out and crash with an error.
                 if CFG.approach == "gnn_option_policy":
                     reset = False
                 else:

--- a/predicators/option_model.py
+++ b/predicators/option_model.py
@@ -146,9 +146,12 @@ class _BehaviorOptionModel(_OptionModelBase):
                     env.current_ig_state_to_state(
                         save_state=False,
                         use_test_scene=env.task_instance_id >= 10)):
-                load_checkpoint_state(state, env, reset=True)
+                if CFG.approach == "gnn_option_policy":
+                    reset = False
+                else:
+                    reset = True
+                load_checkpoint_state(state, env, reset=reset)
         option.memory["model_controller"](state, env.igibson_behavior_env)
-        # next_state = env.current_ig_state_to_state()
         next_state = env.current_ig_state_to_state(
             use_test_scene=env.task_instance_id >= 10)
         plan, _ = option.memory["planner_result"]

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -1073,6 +1073,7 @@ def _sesame_plan_with_fast_downward(
             logging.info(f"Env Predicates: {env.predicates}")
             logging.info(f"Domain String: {dom_str}")
             logging.info(f"Problem String: {prob_str}")
+            raise PlanningFailure(f"Plan not found with FD! Error: {output}")
         metrics["num_nodes_expanded"] = float(num_nodes_expanded[0])
         metrics["num_nodes_created"] = float(num_nodes_created[0])
         # Extract the skeleton from the output and compute the atoms_sequence.

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -85,6 +85,6 @@ FLAGS:  # general flags
   behavior_ignore_discover_failures: True
   num_train_tasks: 10
   num_test_tasks: 10
-START_SEED: 459
+START_SEED: 462
 NUM_SEEDS: 1
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -20,11 +20,11 @@ APPROACHES:
   #   FLAGS:
   #     strips_learner: "cluster_and_intersect"
   #     disable_harmlessness_check: True
-  cluster_and_search:  # LOFT baseline.
-    NAME: "nsrt_learning"
-    FLAGS:
-      strips_learner: "cluster_and_search"
-      disable_harmlessness_check: True
+  # cluster_and_search:  # LOFT baseline.
+  #   NAME: "nsrt_learning"
+  #   FLAGS:
+  #     strips_learner: "cluster_and_search"
+  #     disable_harmlessness_check: True
   # pred_error:  # Prediction error baseline that optimizes via hill climbing.
   #   NAME: "nsrt_learning"
   #   FLAGS: 
@@ -32,8 +32,8 @@ APPROACHES:
   #     disable_harmlessness_check: True
   # NOTE: Set the 'plan_only_eval' flag to false when running either
   # of the below GNN approaches.
-  # gnn_shooting:  # Model-based GNN option policy baseline.
-  #   NAME: "gnn_option_policy"
+  gnn_shooting:  # Model-based GNN option policy baseline.
+    NAME: "gnn_option_policy"
   # NOTE: this needs to run after Model-based GNN has already been run.
   # gnn_modelfree:  # Model-free GNN option policy baseline.
   #   NAME: "gnn_option_policy"
@@ -79,12 +79,12 @@ FLAGS:  # general flags
   offline_data_planning_timeout: 2000.0
   timeout: 2000.0
   # NOTE: set below to False when using GNN's!
-  plan_only_eval: True #False
+  plan_only_eval: False
   sesame_task_planner: fdsat
   behavior_override_learned_samplers: True
   behavior_ignore_discover_failures: True
   num_train_tasks: 10
   num_test_tasks: 10
-START_SEED: 462
-NUM_SEEDS: 1
+START_SEED: 456
+NUM_SEEDS: 3
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -86,5 +86,5 @@ FLAGS:  # general flags
   num_train_tasks: 10
   num_test_tasks: 10
 START_SEED: 456
-NUM_SEEDS: 10
+NUM_SEEDS: 5
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -85,6 +85,6 @@ FLAGS:  # general flags
   behavior_ignore_discover_failures: True
   num_train_tasks: 10
   num_test_tasks: 10
-START_SEED: 456
+START_SEED: 461
 NUM_SEEDS: 5
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -15,21 +15,21 @@ APPROACHES:
   #   NAME: "nsrt_learning"
   #   FLAGS:
   #     strips_learner: pnad_search
-  cluster_and_intersect:  # Cluster-and-intersect baseline.
-    NAME: "nsrt_learning"
-    FLAGS:
-      strips_learner: "cluster_and_intersect"
-      disable_harmlessness_check: True
-  cluster_and_search:  # LOFT baseline.
-    NAME: "nsrt_learning"
-    FLAGS:
-      strips_learner: "cluster_and_search"
-      disable_harmlessness_check: True
-  # pred_error:  # Prediction error baseline that optimizes via hill climbing.
+  # cluster_and_intersect:  # Cluster-and-intersect baseline.
   #   NAME: "nsrt_learning"
-  #   FLAGS: 
-  #     strips_learner: "cluster_and_intersect_sideline_prederror" 
+  #   FLAGS:
+  #     strips_learner: "cluster_and_intersect"
   #     disable_harmlessness_check: True
+  # cluster_and_search:  # LOFT baseline.
+  #   NAME: "nsrt_learning"
+  #   FLAGS:
+  #     strips_learner: "cluster_and_search"
+  #     disable_harmlessness_check: True
+  pred_error:  # Prediction error baseline that optimizes via hill climbing.
+    NAME: "nsrt_learning"
+    FLAGS: 
+      strips_learner: "cluster_and_intersect_sideline_prederror" 
+      disable_harmlessness_check: True
   # NOTE: Set the 'plan_only_eval' flag to false when running either
   # of the below GNN approaches.
   # gnn_shooting:  # Model-based GNN option policy baseline.

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -20,11 +20,11 @@ APPROACHES:
   #   FLAGS:
   #     strips_learner: "cluster_and_intersect"
   #     disable_harmlessness_check: True
-  # cluster_and_search:  # LOFT baseline.
-  #   NAME: "nsrt_learning"
-  #   FLAGS:
-  #     strips_learner: "cluster_and_search"
-  #     disable_harmlessness_check: True
+  cluster_and_search:  # LOFT baseline.
+    NAME: "nsrt_learning"
+    FLAGS:
+      strips_learner: "cluster_and_search"
+      disable_harmlessness_check: True
   # pred_error:  # Prediction error baseline that optimizes via hill climbing.
   #   NAME: "nsrt_learning"
   #   FLAGS: 
@@ -32,8 +32,8 @@ APPROACHES:
   #     disable_harmlessness_check: True
   # NOTE: Set the 'plan_only_eval' flag to false when running either
   # of the below GNN approaches.
-  gnn_shooting:  # Model-based GNN option policy baseline.
-    NAME: "gnn_option_policy"
+  # gnn_shooting:  # Model-based GNN option policy baseline.
+  #   NAME: "gnn_option_policy"
   # NOTE: this needs to run after Model-based GNN has already been run.
   # gnn_modelfree:  # Model-free GNN option policy baseline.
   #   NAME: "gnn_option_policy"
@@ -79,12 +79,12 @@ FLAGS:  # general flags
   offline_data_planning_timeout: 2000.0
   timeout: 2000.0
   # NOTE: set below to False when using GNN's!
-  plan_only_eval: False
+  plan_only_eval: True #False
   sesame_task_planner: fdsat
   behavior_override_learned_samplers: True
   behavior_ignore_discover_failures: True
   num_train_tasks: 10
   num_test_tasks: 10
-START_SEED: 456
-NUM_SEEDS: 10
+START_SEED: 459
+NUM_SEEDS: 1
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -25,15 +25,15 @@ APPROACHES:
   #   FLAGS:
   #     strips_learner: "cluster_and_search"
   #     disable_harmlessness_check: True
-  pred_error:  # Prediction error baseline that optimizes via hill climbing.
-    NAME: "nsrt_learning"
-    FLAGS: 
-      strips_learner: "cluster_and_intersect_sideline_prederror" 
-      disable_harmlessness_check: True
+  # pred_error:  # Prediction error baseline that optimizes via hill climbing.
+  #   NAME: "nsrt_learning"
+  #   FLAGS: 
+  #     strips_learner: "cluster_and_intersect_sideline_prederror" 
+  #     disable_harmlessness_check: True
   # NOTE: Set the 'plan_only_eval' flag to false when running either
   # of the below GNN approaches.
-  # gnn_shooting:  # Model-based GNN option policy baseline.
-  #   NAME: "gnn_option_policy"
+  gnn_shooting:  # Model-based GNN option policy baseline.
+    NAME: "gnn_option_policy"
   # NOTE: this needs to run after Model-based GNN has already been run.
   # gnn_modelfree:  # Model-free GNN option policy baseline.
   #   NAME: "gnn_option_policy"
@@ -79,7 +79,7 @@ FLAGS:  # general flags
   offline_data_planning_timeout: 2000.0
   timeout: 2000.0
   # NOTE: set below to False when using GNN's!
-  plan_only_eval: True #False
+  plan_only_eval: False
   sesame_task_planner: fdsat
   behavior_override_learned_samplers: True
   behavior_ignore_discover_failures: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -32,13 +32,13 @@ APPROACHES:
   #     disable_harmlessness_check: True
   # NOTE: Set the 'plan_only_eval' flag to false when running either
   # of the below GNN approaches.
-  gnn_shooting:  # Model-based GNN option policy baseline.
-    NAME: "gnn_option_policy"
-  # NOTE: this needs to run after Model-based GNN has already been run.
-  # gnn_modelfree:  # Model-free GNN option policy baseline.
+  # gnn_shooting:  # Model-based GNN option policy baseline.
   #   NAME: "gnn_option_policy"
-  #   FLAGS:
-  #     gnn_option_policy_solve_with_shooting: False
+  # NOTE: this needs to run after Model-based GNN has already been run.
+  gnn_modelfree:  # Model-free GNN option policy baseline.
+    NAME: "gnn_option_policy"
+    FLAGS:
+      gnn_option_policy_solve_with_shooting: False
 ENVS:
   # collecting-aluminum-cans-Ihlen_1_int:
   #   NAME: "behavior"
@@ -86,5 +86,5 @@ FLAGS:  # general flags
   num_train_tasks: 10
   num_test_tasks: 10
 START_SEED: 456
-NUM_SEEDS: 3
+NUM_SEEDS: 10
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -85,6 +85,6 @@ FLAGS:  # general flags
   behavior_ignore_discover_failures: True
   num_train_tasks: 10
   num_test_tasks: 10
-START_SEED: 461
-NUM_SEEDS: 5
+START_SEED: 456
+NUM_SEEDS: 10
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -9,27 +9,27 @@
 # --supercloud_dir ~/GitHub/predicators_behavior
 ---
 APPROACHES:
-  oracle: # Oracle
-    NAME: "oracle"
+  # oracle: # Oracle
+  #   NAME: "oracle"
   pnad_search: # PNAD search approach.
     NAME: "nsrt_learning"
     FLAGS:
       strips_learner: pnad_search
-  cluster_and_intersect:  # Cluster-and-intersect baseline.
-    NAME: "nsrt_learning"
-    FLAGS:
-      strips_learner: "cluster_and_intersect"
-      disable_harmlessness_check: True
-  cluster_and_search:  # LOFT baseline.
-    NAME: "nsrt_learning"
-    FLAGS:
-      strips_learner: "cluster_and_search"
-      disable_harmlessness_check: True
-  pred_error:  # Prediction error baseline that optimizes via hill climbing.
-    NAME: "nsrt_learning"
-    FLAGS: 
-      strips_learner: "cluster_and_intersect_sideline_prederror" 
-      disable_harmlessness_check: True
+  # cluster_and_intersect:  # Cluster-and-intersect baseline.
+  #   NAME: "nsrt_learning"
+  #   FLAGS:
+  #     strips_learner: "cluster_and_intersect"
+  #     disable_harmlessness_check: True
+  # cluster_and_search:  # LOFT baseline.
+  #   NAME: "nsrt_learning"
+  #   FLAGS:
+  #     strips_learner: "cluster_and_search"
+  #     disable_harmlessness_check: True
+  # pred_error:  # Prediction error baseline that optimizes via hill climbing.
+  #   NAME: "nsrt_learning"
+  #   FLAGS: 
+  #     strips_learner: "cluster_and_intersect_sideline_prederror" 
+  #     disable_harmlessness_check: True
   # NOTE: Set the 'plan_only_eval' flag to false when running either
   # of the below GNN approaches.
   # gnn_shooting:  # Model-based GNN option policy baseline.
@@ -40,30 +40,30 @@ APPROACHES:
   #   FLAGS:
   #     gnn_option_policy_solve_with_shooting: False
 ENVS:
-  collecting-aluminum-cans-Ihlen_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_train_scene_name: Ihlen_1_int
-      behavior_test_scene_name: Pomaria_2_int
-      behavior_task_list: "[collecting_aluminum_cans]"
-      behavior_option_model_eval: True
-      horizon: 1000
-  opening-presents-Pomaria_2_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_train_scene_name: Pomaria_2_int
-      behavior_test_scene_name: Benevolence_2_int
-      behavior_task_list: "[opening_presents]"
-      behavior_option_model_eval: True
-      horizon: 1000
-  locking-every-window-Merom_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_train_scene_name: Merom_1_int
-      behavior_test_scene_name: Wainscott_0_int
-      behavior_task_list: "[locking_every_window]"
-      behavior_option_model_eval: True
-      horizon: 1000
+  # collecting-aluminum-cans-Ihlen_1_int:
+  #   NAME: "behavior"
+  #   FLAGS:
+  #     behavior_train_scene_name: Ihlen_1_int
+  #     behavior_test_scene_name: Pomaria_2_int
+  #     behavior_task_list: "[collecting_aluminum_cans]"
+  #     behavior_option_model_eval: True
+  #     horizon: 1000
+  # opening-presents-Pomaria_2_int:
+  #   NAME: "behavior"
+  #   FLAGS:
+  #     behavior_train_scene_name: Pomaria_2_int
+  #     behavior_test_scene_name: Benevolence_2_int
+  #     behavior_task_list: "[opening_presents]"
+  #     behavior_option_model_eval: True
+  #     horizon: 1000
+  # locking-every-window-Merom_1_int:
+  #   NAME: "behavior"
+  #   FLAGS:
+  #     behavior_train_scene_name: Merom_1_int
+  #     behavior_test_scene_name: Wainscott_0_int
+  #     behavior_task_list: "[locking_every_window]"
+  #     behavior_option_model_eval: True
+  #     horizon: 1000
   sorting-books-Pomaria_1_int:
     NAME: "behavior"
     FLAGS:
@@ -76,14 +76,15 @@ ARGS:
   - "load_data"
   - "load_atoms"
 FLAGS:  # general flags
-  offline_data_planning_timeout: 500.0
-  timeout: 500.0
+  offline_data_planning_timeout: 2000.0
+  timeout: 2000.0
   # NOTE: set below to False when using GNN's!
   plan_only_eval: True #False
   sesame_task_planner: fdsat
   behavior_override_learned_samplers: True
+  behavior_ignore_discover_failures: True
   num_train_tasks: 10
   num_test_tasks: 10
 START_SEED: 456
-NUM_SEEDS: 10
+NUM_SEEDS: 5
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -9,61 +9,60 @@
 # --supercloud_dir ~/GitHub/predicators_behavior
 ---
 APPROACHES:
-  # oracle: # Oracle
-  #   NAME: "oracle"
-  # pnad_search: # PNAD search approach.
-  #   NAME: "nsrt_learning"
-  #   FLAGS:
-  #     strips_learner: pnad_search
-  # cluster_and_intersect:  # Cluster-and-intersect baseline.
-  #   NAME: "nsrt_learning"
-  #   FLAGS:
-  #     strips_learner: "cluster_and_intersect"
-  #     disable_harmlessness_check: True
-  # cluster_and_search:  # LOFT baseline.
-  #   NAME: "nsrt_learning"
-  #   FLAGS:
-  #     strips_learner: "cluster_and_search"
-  #     disable_harmlessness_check: True
-  # pred_error:  # Prediction error baseline that optimizes via hill climbing.
-  #   NAME: "nsrt_learning"
-  #   FLAGS: 
-  #     strips_learner: "cluster_and_intersect_sideline_prederror" 
-  #     disable_harmlessness_check: True
+  oracle: # Oracle
+    NAME: "oracle"
+  pnad_search: # PNAD search approach.
+    NAME: "nsrt_learning"
+    FLAGS:
+      strips_learner: pnad_search
+  cluster_and_intersect:  # Cluster-and-intersect baseline.
+    NAME: "nsrt_learning"
+    FLAGS:
+      strips_learner: "cluster_and_intersect"
+      disable_harmlessness_check: True
+  cluster_and_search:  # LOFT baseline.
+    NAME: "nsrt_learning"
+    FLAGS:
+      strips_learner: "cluster_and_search"
+      disable_harmlessness_check: True
+  pred_error:  # Prediction error baseline that optimizes via hill climbing.
+    NAME: "nsrt_learning"
+    FLAGS: 
+      strips_learner: "cluster_and_intersect_sideline_prederror" 
+      disable_harmlessness_check: True
   # NOTE: Set the 'plan_only_eval' flag to false when running either
   # of the below GNN approaches.
-  gnn_shooting:  # Model-based GNN option policy baseline.
-    NAME: "gnn_option_policy"
-  # NOTE: this needs to run after Model-based GNN has already been run.
-  # gnn_modelfree:  # Model-free GNN option policy baseline.
+  # gnn_shooting:  # Model-based GNN option policy baseline.
+  #   NAME: "gnn_option_policy"
+  # Model-free GNN option policy baseline.
   #   NAME: "gnn_option_policy"
   #   FLAGS:
   #     gnn_option_policy_solve_with_shooting: False
 ENVS:
-  # collecting-aluminum-cans-Ihlen_1_int:
-  #   NAME: "behavior"
-  #   FLAGS:
-  #     behavior_train_scene_name: Ihlen_1_int
-  #     behavior_test_scene_name: Pomaria_2_int
-  #     behavior_task_list: "[collecting_aluminum_cans]"
-  #     behavior_option_model_eval: True
-  #     horizon: 1000
-  # opening-presents-Pomaria_2_int:
-  #   NAME: "behavior"
-  #   FLAGS:
-  #     behavior_train_scene_name: Pomaria_2_int
-  #     behavior_test_scene_name: Benevolence_2_int
-  #     behavior_task_list: "[opening_presents]"
-  #     behavior_option_model_eval: True
-  #     horizon: 1000
-  # locking-every-window-Merom_1_int:
-  #   NAME: "behavior"
-  #   FLAGS:
-  #     behavior_train_scene_name: Merom_1_int
-  #     behavior_test_scene_name: Wainscott_0_int
-  #     behavior_task_list: "[locking_every_window]"
-  #     behavior_option_model_eval: True
-  #     horizon: 1000
+  collecting-aluminum-cans-Ihlen_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_train_scene_name: Ihlen_1_int
+      behavior_test_scene_name: Pomaria_2_int
+      behavior_task_list: "[collecting_aluminum_cans]"
+      behavior_option_model_eval: True
+      horizon: 1000
+  opening-presents-Pomaria_2_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_train_scene_name: Pomaria_2_int
+      behavior_test_scene_name: Benevolence_2_int
+      behavior_task_list: "[opening_presents]"
+      behavior_option_model_eval: True
+      horizon: 1000
+  locking-every-window-Merom_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_train_scene_name: Merom_1_int
+      behavior_test_scene_name: Wainscott_0_int
+      behavior_task_list: "[locking_every_window]"
+      behavior_option_model_eval: True
+      horizon: 1000
   sorting-books-Pomaria_1_int:
     NAME: "behavior"
     FLAGS:
@@ -76,10 +75,11 @@ ARGS:
   - "load_data"
   - "load_atoms"
 FLAGS:  # general flags
-  offline_data_planning_timeout: 2000.0
-  timeout: 2000.0
+  # NOTE: set below timeouts to 2000.0 for sorting-book.
+  offline_data_planning_timeout: 500 #2000.0
+  timeout: 500 #2000.0
   # NOTE: set below to False when using GNN's!
-  plan_only_eval: False
+  plan_only_eval: True #False
   sesame_task_planner: fdsat
   behavior_override_learned_samplers: True
   behavior_ignore_discover_failures: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -11,20 +11,20 @@
 APPROACHES:
   # oracle: # Oracle
   #   NAME: "oracle"
-  pnad_search: # PNAD search approach.
+  # pnad_search: # PNAD search approach.
+  #   NAME: "nsrt_learning"
+  #   FLAGS:
+  #     strips_learner: pnad_search
+  cluster_and_intersect:  # Cluster-and-intersect baseline.
     NAME: "nsrt_learning"
     FLAGS:
-      strips_learner: pnad_search
-  # cluster_and_intersect:  # Cluster-and-intersect baseline.
-  #   NAME: "nsrt_learning"
-  #   FLAGS:
-  #     strips_learner: "cluster_and_intersect"
-  #     disable_harmlessness_check: True
-  # cluster_and_search:  # LOFT baseline.
-  #   NAME: "nsrt_learning"
-  #   FLAGS:
-  #     strips_learner: "cluster_and_search"
-  #     disable_harmlessness_check: True
+      strips_learner: "cluster_and_intersect"
+      disable_harmlessness_check: True
+  cluster_and_search:  # LOFT baseline.
+    NAME: "nsrt_learning"
+    FLAGS:
+      strips_learner: "cluster_and_search"
+      disable_harmlessness_check: True
   # pred_error:  # Prediction error baseline that optimizes via hill climbing.
   #   NAME: "nsrt_learning"
   #   FLAGS: 
@@ -85,6 +85,6 @@ FLAGS:  # general flags
   behavior_ignore_discover_failures: True
   num_train_tasks: 10
   num_test_tasks: 10
-START_SEED: 461
-NUM_SEEDS: 5
+START_SEED: 456
+NUM_SEEDS: 10
 USE_GPU: True

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -32,13 +32,13 @@ APPROACHES:
   #     disable_harmlessness_check: True
   # NOTE: Set the 'plan_only_eval' flag to false when running either
   # of the below GNN approaches.
-  # gnn_shooting:  # Model-based GNN option policy baseline.
-  #   NAME: "gnn_option_policy"
-  # NOTE: this needs to run after Model-based GNN has already been run.
-  gnn_modelfree:  # Model-free GNN option policy baseline.
+  gnn_shooting:  # Model-based GNN option policy baseline.
     NAME: "gnn_option_policy"
-    FLAGS:
-      gnn_option_policy_solve_with_shooting: False
+  # NOTE: this needs to run after Model-based GNN has already been run.
+  # gnn_modelfree:  # Model-free GNN option policy baseline.
+  #   NAME: "gnn_option_policy"
+  #   FLAGS:
+  #     gnn_option_policy_solve_with_shooting: False
 ENVS:
   # collecting-aluminum-cans-Ihlen_1_int:
   #   NAME: "behavior"
@@ -84,7 +84,7 @@ FLAGS:  # general flags
   behavior_override_learned_samplers: True
   behavior_ignore_discover_failures: True
   num_train_tasks: 10
-  num_test_tasks: 10
-START_SEED: 456
-NUM_SEEDS: 10
+  num_test_tasks: 0
+START_SEED: 463
+NUM_SEEDS: 2
 USE_GPU: True


### PR DESCRIPTION
The big change here is that previously, we were not calling `load_checkpoint_state` to set the underlying iGibson state to the correct one before starting to run any of our GNN approaches. This is critical, and was leading to a noticeable error on `sorting-books` because the relevant objects set between the training and test tasks are very different (which isn't the case for other tasks).
We also change the option model to not reset state on loading because this gets way too expensive for the GNN's.
Finally, we raise a `PlanningTimeout` error if FD encounters an issue for any reason, which we should've been doing previously but just never encountered until now.