### PR TITLE
Update instructions for supercloud cpu-only iGibson usage!

### DIFF
--- a/behavior.md
+++ b/behavior.md
@@ -49,7 +49,10 @@ python predicators/main.py --env behavior --approach oracle --option_model_name 
 ## Installing on MIT Supercloud
 First, follow steps in our [Supercloud guide](supercloud.md) to get an account and setup this repository on Supercloud.
 
-Next, simply follow the steps linked in the [above section](#installation) (though ignore the first step; supercloud already has the iGibson pre-reqs installed)! Note that for various driver-related reasons, this code only works on GPU-machines with supercloud (so always remember to request a GPU when submitting jobs involving this codebase).
+Next, simply follow the steps linked in the [above section](#installation) (though ignore the first step; supercloud already has the iGibson pre-reqs installed)! Importantly, we have a separate branch of iGibson that *completely disables* rendering so that (1) the simulator runs on CPU-only nodes on SuperCloud, and (2) planning is extremely fast. To use this branch (recommended), `cd` to the iGibson repo and run:
+`git checkout no-render`
+
+Note that if you want to use the master branch of iGibson on SuperCloud, you will need to exclusively request GPU nodes. 
 
 To test installation, do:
 ```
@@ -86,7 +89,7 @@ python predicators/main.py --env behavior --approach oracle --option_model_name 
 * Set `--behavior_scene_name` to the name of the house setting (e.g. `Pomaria_1_int`) you want to try running the particular task in. Note that not all tasks are available in all houses (e.g. `re-shelving_library_books` might only be available with `Pomaria_1_int`).
 * If you'd like to see a visual of the agent planning in iGibson, set the command line argument `--behavior_mode simple`. If you want to run in headless mode without any visuals, leave the default (i.e `--behavior_mode headless`).
 * Be sure to set `--plan_only_eval True`: this is necessary to account for the fact that the iGibson simulator is non-deterministic when saving and loading states (which is currently an unresolved bug).
-* Example command: `python predicators/main.py --env behavior --approach oracle --option_model_name oracle_behavior --num_train_tasks 0 --num_test_tasks 1 --behavior_scene_name Pomaria_2_int --behavior_task_list "[opening_packages]" --seed 1000 --offline_data_planning_timeout 500.0 --timeout 500.0 --behavior_option_model_eval True --plan_only_eval True`.
+* Example command: `python predicators/main.py --env behavior --approach oracle --option_model_name oracle_behavior --num_train_tasks 0 --num_test_tasks 1 --behavior_train_scene_name Pomaria_2_int --behavior_test_scene_name Pomaria_2_int --behavior_task_list "[opening_packages]" --seed 1000 --offline_data_planning_timeout 500.0 --timeout 500.0 --behavior_option_model_eval True --plan_only_eval True`.
 
 ## Troubleshooting
 ### Visualizing what the robot is doing

--- a/scripts/configs/behavior_20_evaluation.yaml
+++ b/scripts/configs/behavior_20_evaluation.yaml
@@ -157,4 +157,4 @@ FLAGS:  # general flags
   num_test_tasks: 5
 START_SEED: 0
 NUM_SEEDS: 1
-USE_GPU: True
+USE_GPU: False

--- a/scripts/configs/behavior_all_tasks_oracle.yaml
+++ b/scripts/configs/behavior_all_tasks_oracle.yaml
@@ -717,4 +717,4 @@ FLAGS:  # general flags
   num_test_tasks: 5
 START_SEED: 0
 NUM_SEEDS: 1
-USE_GPU: True
+USE_GPU: False

--- a/scripts/configs/behavior_example.yaml
+++ b/scripts/configs/behavior_example.yaml
@@ -30,4 +30,4 @@ FLAGS:  # general flags
   num_test_tasks: 10
 START_SEED: 456
 NUM_SEEDS: 3
-USE_GPU: True
+USE_GPU: False

--- a/scripts/configs/behavior_pick_place_data_collection.yaml
+++ b/scripts/configs/behavior_pick_place_data_collection.yaml
@@ -50,4 +50,4 @@ FLAGS:  # general flags
   num_test_tasks: 0
 START_SEED: 456
 NUM_SEEDS: 10
-USE_GPU: True
+USE_GPU: False

--- a/scripts/configs/behavior_pick_place_data_collection.yaml
+++ b/scripts/configs/behavior_pick_place_data_collection.yaml
@@ -23,27 +23,27 @@ ENVS:
       behavior_test_scene_name: Ihlen_1_int
       behavior_task_list: "[collecting_aluminum_cans]"
       behavior_option_model_eval: True
-  # opening-presents-Pomaria_2_int:
-  #   NAME: "behavior"
-  #   FLAGS:
-  #     behavior_train_scene_name: Pomaria_2_int
-  #     behavior_test_scene_name: Pomaria_2_int
-  #     behavior_task_list: "[opening_presents]"
-  #     behavior_option_model_eval: True
-  # locking-every-window-Merom_1_int:
-  #   NAME: "behavior"
-  #   FLAGS:
-  #     behavior_train_scene_name: Merom_1_int
-  #     behavior_test_scene_name: Merom_1_int
-  #     behavior_task_list: "[locking_every_window]"
-  #     behavior_option_model_eval: True
-  # sorting-books-Pomaria_1_int:
-  #   NAME: "behavior"
-  #   FLAGS:
-  #     behavior_train_scene_name: Pomaria_1_int
-  #     behavior_test_scene_name: Pomaria_1_int
-  #     behavior_task_list: "[sorting_books]"
-  #     behavior_option_model_eval: True
+  opening-presents-Pomaria_2_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_train_scene_name: Pomaria_2_int
+      behavior_test_scene_name: Pomaria_2_int
+      behavior_task_list: "[opening_presents]"
+      behavior_option_model_eval: True
+  locking-every-window-Merom_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_train_scene_name: Merom_1_int
+      behavior_test_scene_name: Merom_1_int
+      behavior_task_list: "[locking_every_window]"
+      behavior_option_model_eval: True
+  sorting-books-Pomaria_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_train_scene_name: Pomaria_1_int
+      behavior_test_scene_name: Pomaria_1_int
+      behavior_task_list: "[sorting_books]"
+      behavior_option_model_eval: True
 ARGS: {}
 FLAGS:  # general flags
   num_train_tasks: 10

--- a/scripts/configs/behavior_pick_place_data_collection.yaml
+++ b/scripts/configs/behavior_pick_place_data_collection.yaml
@@ -23,31 +23,31 @@ ENVS:
       behavior_test_scene_name: Ihlen_1_int
       behavior_task_list: "[collecting_aluminum_cans]"
       behavior_option_model_eval: True
-  opening-presents-Pomaria_2_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_train_scene_name: Pomaria_2_int
-      behavior_test_scene_name: Pomaria_2_int
-      behavior_task_list: "[opening_presents]"
-      behavior_option_model_eval: True
-  locking-every-window-Merom_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_train_scene_name: Merom_1_int
-      behavior_test_scene_name: Merom_1_int
-      behavior_task_list: "[locking_every_window]"
-      behavior_option_model_eval: True
-  sorting-books-Pomaria_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_train_scene_name: Pomaria_1_int
-      behavior_test_scene_name: Pomaria_1_int
-      behavior_task_list: "[sorting_books]"
-      behavior_option_model_eval: True
+  # opening-presents-Pomaria_2_int:
+  #   NAME: "behavior"
+  #   FLAGS:
+  #     behavior_train_scene_name: Pomaria_2_int
+  #     behavior_test_scene_name: Pomaria_2_int
+  #     behavior_task_list: "[opening_presents]"
+  #     behavior_option_model_eval: True
+  # locking-every-window-Merom_1_int:
+  #   NAME: "behavior"
+  #   FLAGS:
+  #     behavior_train_scene_name: Merom_1_int
+  #     behavior_test_scene_name: Merom_1_int
+  #     behavior_task_list: "[locking_every_window]"
+  #     behavior_option_model_eval: True
+  # sorting-books-Pomaria_1_int:
+  #   NAME: "behavior"
+  #   FLAGS:
+  #     behavior_train_scene_name: Pomaria_1_int
+  #     behavior_test_scene_name: Pomaria_1_int
+  #     behavior_task_list: "[sorting_books]"
+  #     behavior_option_model_eval: True
 ARGS: {}
 FLAGS:  # general flags
   num_train_tasks: 10
   num_test_tasks: 0
 START_SEED: 456
-NUM_SEEDS: 10
+NUM_SEEDS: 1
 USE_GPU: False

--- a/scripts/configs/behavior_pick_place_evaluation.yaml
+++ b/scripts/configs/behavior_pick_place_evaluation.yaml
@@ -87,4 +87,4 @@ FLAGS:  # general flags
   num_test_tasks: 0
 START_SEED: 463
 NUM_SEEDS: 2
-USE_GPU: True
+USE_GPU: False

--- a/scripts/configs/behavior_pick_place_learning.yaml
+++ b/scripts/configs/behavior_pick_place_learning.yaml
@@ -84,4 +84,4 @@ FLAGS:  # general flags
   num_test_tasks: 10
 START_SEED: 456
 NUM_SEEDS: 3
-USE_GPU: True
+USE_GPU: False

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from predicators import utils
-from predicators.ml_models import BinaryClassifierEnsemble, CNNRegressor, \
+from predicators.ml_models import BinaryClassifierEnsemble, \
     DegenerateMLPDistributionRegressor, ImplicitMLPRegressor, \
     KNeighborsClassifier, KNeighborsRegressor, MLPBinaryClassifier, \
     MLPRegressor, NeuralGaussianRegressor
@@ -92,38 +92,6 @@ def test_implicit_mlp_regressor():
     model._inference_method = "not a real inference method"  # pylint: disable=protected-access
     with pytest.raises(NotImplementedError):
         model.predict(x)
-
-
-def test_basic_cnn_regressor():
-    """Tests for CNNRegressor."""
-    utils.reset_config()
-    input_size = (3, 9, 6)
-    output_size = 2
-    num_samples = 5
-    model = CNNRegressor(seed=123,
-                         conv_channel_nums=[1, 1],
-                         conv_kernel_sizes=[3, 1],
-                         linear_hid_sizes=[32, 32],
-                         max_train_iters=100,
-                         clip_gradients=True,
-                         clip_value=5,
-                         learning_rate=1e-3)
-    X = np.ones((num_samples, *input_size))
-    Y = np.zeros((num_samples, output_size))
-    model.fit(X, Y)
-    x = np.ones(input_size)
-    predicted_y = model.predict(x)
-    expected_y = np.zeros(output_size)
-    assert predicted_y.shape == expected_y.shape
-    assert np.allclose(predicted_y, expected_y, atol=1e-2)
-    # Test with nonzero outputs.
-    Y = 75 * np.ones((num_samples, output_size))
-    model.fit(X, Y)
-    x = np.ones(input_size)
-    predicted_y = model.predict(x)
-    expected_y = 75 * np.ones(output_size)
-    assert predicted_y.shape == expected_y.shape
-    assert np.allclose(predicted_y, expected_y, atol=1e-2)
 
 
 def test_neural_gaussian_regressor():

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -1,12 +1,14 @@
 """Tests for models."""
 
+import logging
 import time
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
 from predicators import utils
-from predicators.ml_models import BinaryClassifierEnsemble, \
+from predicators.ml_models import BinaryClassifierEnsemble, CNNRegressor, \
     DegenerateMLPDistributionRegressor, ImplicitMLPRegressor, \
     KNeighborsClassifier, KNeighborsRegressor, MLPBinaryClassifier, \
     MLPRegressor, NeuralGaussianRegressor
@@ -92,6 +94,38 @@ def test_implicit_mlp_regressor():
         model.predict(x)
 
 
+def test_basic_cnn_regressor():
+    """Tests for CNNRegressor."""
+    utils.reset_config()
+    input_size = (3, 9, 6)
+    output_size = 2
+    num_samples = 5
+    model = CNNRegressor(seed=123,
+                         conv_channel_nums=[1, 1],
+                         conv_kernel_sizes=[3, 1],
+                         linear_hid_sizes=[32, 32],
+                         max_train_iters=100,
+                         clip_gradients=True,
+                         clip_value=5,
+                         learning_rate=1e-3)
+    X = np.ones((num_samples, *input_size))
+    Y = np.zeros((num_samples, output_size))
+    model.fit(X, Y)
+    x = np.ones(input_size)
+    predicted_y = model.predict(x)
+    expected_y = np.zeros(output_size)
+    assert predicted_y.shape == expected_y.shape
+    assert np.allclose(predicted_y, expected_y, atol=1e-2)
+    # Test with nonzero outputs.
+    Y = 75 * np.ones((num_samples, output_size))
+    model.fit(X, Y)
+    x = np.ones(input_size)
+    predicted_y = model.predict(x)
+    expected_y = 75 * np.ones(output_size)
+    assert predicted_y.shape == expected_y.shape
+    assert np.allclose(predicted_y, expected_y, atol=1e-2)
+
+
 def test_neural_gaussian_regressor():
     """Tests for NeuralGaussianRegressor."""
     utils.reset_config()
@@ -172,17 +206,18 @@ def test_mlp_classifier():
     assert prediction
     assert model.predict_proba(np.ones(input_size)) > 0.5
     # Test for early stopping
-    start_time = time.perf_counter()
     model = MLPBinaryClassifier(seed=123,
                                 balance_data=True,
                                 max_train_iters=100000,
                                 learning_rate=1e-2,
-                                n_iter_no_change=1,
+                                n_iter_no_change=-1,
                                 hid_sizes=[32, 32],
                                 n_reinitialize_tries=1,
-                                weight_init="default")
-    model.fit(X, y)
-    assert time.perf_counter() - start_time < 3, "Didn't early stop"
+                                weight_init="default",
+                                train_print_every=1)
+    with patch.object(logging, "info", return_value=None) as mock_logging_info:
+        model.fit(X, y)
+    assert mock_logging_info.call_count < 5
     # Test with no positive examples.
     num_class_samples = 1000
     X = np.concatenate([

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -181,8 +181,7 @@ def test_mlp_classifier():
                                 n_iter_no_change=-1,
                                 hid_sizes=[32, 32],
                                 n_reinitialize_tries=1,
-                                weight_init="default",
-                                train_print_every=1)
+                                weight_init="default")
     with patch.object(logging, "info", return_value=None) as mock_logging_info:
         model.fit(X, y)
     assert mock_logging_info.call_count < 5


### PR DESCRIPTION
This PR updates our supercloud instructions to use the new `no-render` branch of the LIS fork of `iGibson`. This allows us to (1) launch SuperCloud jobs for BEHAVIOR without needing GPU's (which should be much faster because there are far more CPU nodes in the cluster), and (2) massively speed up bilevel planning (because rendering was previously taking up a lot of the compute during planning). As a point of reference, these new changes allow our oracle to plan on 10 seeds of `opening_presents` in ~90s total time!